### PR TITLE
Update to use iotaa 'ref' instead of 'refs'

### DIFF
--- a/recipe/meta.json
+++ b/recipe/meta.json
@@ -5,7 +5,7 @@
   "packages": {
     "dev": [
       "docformatter ==1.7.*",
-      "iotaa >=1.2.3",
+      "iotaa >=1.3",
       "jq ==1.7.*",
       "make ==4.4.*",
       "met2go ==11.0.*",
@@ -23,12 +23,12 @@
       "ruff ==0.11.*",
       "seaborn ==0.13.*",
       "setuptools",
-      "uwtools ==2.7.*",
+      "uwtools ==2.8.*",
       "xarray >=2023.12,<2025.2",
       "zarr >=3.0,<3.1"
     ],
     "run": [
-      "iotaa >=1.2.3",
+      "iotaa >=1.3",
       "met2go ==11.0.*",
       "netcdf4 >=1.7,<2",
       "pyproj ==3.7.*",
@@ -36,7 +36,7 @@
       "pyyaml ==6.0.*",
       "requests >=2.32,<3",
       "seaborn ==0.13.*",
-      "uwtools ==2.7.*",
+      "uwtools ==2.8.*",
       "xarray >=2023.12,<2025.2",
       "zarr >=3.0,<3.1"
     ]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,14 +16,14 @@ requirements:
     - setuptools
     - {{ python }}
   run:
-    - iotaa >=1.2.3
+    - iotaa >=1.3
     - met2go 11.0.*
     - netcdf4 >=1.7,<2
     - pyproj 3.7.*
     - pyyaml 6.0.*
     - requests >=2.32,<3
     - seaborn 0.13.*
-    - uwtools 2.7.*
+    - uwtools 2.8.*
     - xarray >=2023.12,<2025.2
     - zarr >=3.0,<3.1
     - {{ python }}

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -14,7 +14,7 @@ from unittest.mock import ANY, patch
 
 import pandas as pd
 import xarray as xr
-from iotaa import Node, asset, external, ready, ref
+from iotaa import Node, asset, external, ready
 from pytest import fixture, mark
 
 from wxvx import variables, workflow
@@ -80,28 +80,28 @@ TESTDATA = {
 
 def test_workflow_grids(c, n_grids, noop):
     with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
-        assert len(ref(workflow.grids(c=c))) == n_grids * 3  # forecast, baseline, and comp grids
-        assert len(ref(workflow.grids(c=c, baseline=True, forecast=True))) == n_grids * 3
-        assert len(ref(workflow.grids(c=c, baseline=True, forecast=False))) == n_grids * 2
-        assert len(ref(workflow.grids(c=c, baseline=False, forecast=True))) == n_grids
-        assert len(ref(workflow.grids(c=c, baseline=False, forecast=False))) == 0
+        assert len(workflow.grids(c=c).ref) == n_grids * 3  # forecast, baseline, and comp grids
+        assert len(workflow.grids(c=c, baseline=True, forecast=True).ref) == n_grids * 3
+        assert len(workflow.grids(c=c, baseline=True, forecast=False).ref) == n_grids * 2
+        assert len(workflow.grids(c=c, baseline=False, forecast=True).ref) == n_grids
+        assert len(workflow.grids(c=c, baseline=False, forecast=False).ref) == 0
 
 
 def test_workflow_grids_baseline(c, n_grids, noop):
     with patch.object(workflow, "_grid_grib", noop):
-        assert len(ref(workflow.grids_baseline(c=c))) == n_grids * 2
+        assert len(workflow.grids_baseline(c=c).ref) == n_grids * 2
 
 
 def test_workflow_grids_forecast(c, n_grids, noop):
     with patch.object(workflow, "_grid_nc", noop):
-        assert len(ref(workflow.grids_forecast(c=c))) == n_grids
+        assert len(workflow.grids_forecast(c=c).ref) == n_grids
 
 
 def test_workflow_plots(c, noop):
     cycles = gen_cycles(start=c.cycles.start, step=c.cycles.step, stop=c.cycles.stop)
     with patch.object(workflow, "_plot", noop):
         val = workflow.plots(c=c)
-    assert len(ref(val)) == len(cycles) * sum(
+    assert len(val.ref) == len(cycles) * sum(
         len(list(workflow._stats_and_widths(c, varname)))
         for varname, _ in workflow._varnames_and_levels(c)
     )
@@ -110,7 +110,7 @@ def test_workflow_plots(c, noop):
 def test_workflow_stats(c, noop):
     with patch.object(workflow, "_statreqs", return_value=[noop()]) as _statreqs:
         val = workflow.stats(c=c)
-    assert len(ref(val)) == len(c.variables) + 1  # for 2x SPFH levels
+    assert len(val.ref) == len(c.variables) + 1  # for 2x SPFH levels
 
 
 def test_workflow__existing(fakefs):
@@ -127,7 +127,7 @@ def test_workflow__forecast_dataset(da_with_leadtime, fakefs):
     with patch.object(workflow.xr, "open_dataset", return_value=da_with_leadtime.to_dataset()):
         val = workflow._forecast_dataset(path=path)
     assert ready(val)
-    assert (da_with_leadtime == ref(val).HGT).all()
+    assert (da_with_leadtime == val.ref.HGT).all()
 
 
 def test_workflow__grib_index_data(c, tc):
@@ -148,7 +148,7 @@ def test_workflow__grib_index_data(c, tc):
         val = workflow._grib_index_data(
             c=c, outdir=c.paths.grids_baseline, tc=tc, url=c.baseline.template
         )
-    assert ref(val) == {
+    assert val.ref == {
         "gh-isobaricInhPa-0900": variables.HRRR(
             name="HGT", levstr="900 mb", firstbyte=0, lastbyte=0
         )
@@ -158,7 +158,7 @@ def test_workflow__grib_index_data(c, tc):
 def test_workflow__grib_index_file(c):
     url = f"{c.baseline.template}.idx"
     val = workflow._grib_index_file(outdir=c.paths.grids_baseline, url=url)
-    path: Path = ref(val)
+    path: Path = val.ref
     assert not path.exists()
     path.parent.mkdir(parents=True, exist_ok=True)
     with patch.object(workflow, "fetch") as fetch:
@@ -187,7 +187,7 @@ def test_workflow__grid_grib(c, tc):
     var = variables.Var(name="t", level_type="isobaricInhPa", level=900)
     with patch.object(workflow, "_grib_index_data", wraps=mock) as _grib_index_data:
         val = workflow._grid_grib(c=c, tc=tc, var=var)
-        path = ref(val)
+        path = val.ref
         assert not path.exists()
         ready.set()
         with patch.object(workflow, "fetch") as fetch:
@@ -211,7 +211,7 @@ def test_workflow__grid_nc(c_real_fs, check_cf_metadata, da_with_leadtime, tc):
     object.__setattr__(c_real_fs.forecast, "path", path)
     val = workflow._grid_nc(c=c_real_fs, varname="HGT", tc=tc, var=var)
     assert ready(val)
-    check_cf_metadata(ds=xr.open_dataset(ref(val), decode_timedelta=True), name="HGT", level=level)
+    check_cf_metadata(ds=xr.open_dataset(val.ref, decode_timedelta=True), name="HGT", level=level)
 
 
 def test_workflow__polyfile(fakefs):
@@ -268,7 +268,7 @@ def test_workflow__stat(c, fakefs, tc):
     taskname = "MET stats for baseline 2t-heightAboveGround-0002 at 19700101 00Z 000"
     var = variables.Var(name="2t", level_type="heightAboveGround", level=2)
     kwargs = dict(c=c, varname="T2M", tc=tc, var=var, prefix="foo", source=Source.BASELINE)
-    stat = ref(workflow._stat(**kwargs, dry_run=True))
+    stat = workflow._stat(**kwargs, dry_run=True).ref
     cfgfile = (rundir / stat.stem).with_suffix(".config")
     runscript = (rundir / stat.stem).with_suffix(".sh")
     assert not stat.is_file()

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 from threading import Event
 from types import SimpleNamespace as ns
 from typing import cast
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 
 import pandas as pd
 import xarray as xr
@@ -316,11 +316,9 @@ def test__meta(c):
 @mark.parametrize("dictkey", ["foo", "bar", "baz"])
 def test__prepare_plot_data(dictkey):
     varname, level, dfs, stat, width = TESTDATA[dictkey]
-    reqs = cast(Sequence[Node], ["node1", "node2"])
-    with (
-        patch("iotaa.ref", side_effect=lambda x: f"{x}.stat"),
-        patch("wxvx.workflow.pd.read_csv", side_effect=dfs),
-    ):
+    node = lambda x: Mock(ref=f"{x}.stat", taskname=x)
+    reqs = cast(Sequence[Node], [node("node1"), node("node2")])
+    with patch.object(workflow.pd, "read_csv", side_effect=dfs):
         tdf = workflow._prepare_plot_data(reqs=reqs, stat=stat, width=width)
     assert isinstance(tdf, pd.DataFrame)
     assert stat in tdf.columns

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -14,7 +14,7 @@ from unittest.mock import ANY, patch
 
 import pandas as pd
 import xarray as xr
-from iotaa import Node, asset, external, ready, refs
+from iotaa import Node, asset, external, ready, ref
 from pytest import fixture, mark
 
 from wxvx import variables, workflow
@@ -80,28 +80,28 @@ TESTDATA = {
 
 def test_workflow_grids(c, n_grids, noop):
     with patch.object(workflow, "_grid_grib", noop), patch.object(workflow, "_grid_nc", noop):
-        assert len(refs(workflow.grids(c=c))) == n_grids * 3  # forecast, baseline, and comp grids
-        assert len(refs(workflow.grids(c=c, baseline=True, forecast=True))) == n_grids * 3
-        assert len(refs(workflow.grids(c=c, baseline=True, forecast=False))) == n_grids * 2
-        assert len(refs(workflow.grids(c=c, baseline=False, forecast=True))) == n_grids
-        assert len(refs(workflow.grids(c=c, baseline=False, forecast=False))) == 0
+        assert len(ref(workflow.grids(c=c))) == n_grids * 3  # forecast, baseline, and comp grids
+        assert len(ref(workflow.grids(c=c, baseline=True, forecast=True))) == n_grids * 3
+        assert len(ref(workflow.grids(c=c, baseline=True, forecast=False))) == n_grids * 2
+        assert len(ref(workflow.grids(c=c, baseline=False, forecast=True))) == n_grids
+        assert len(ref(workflow.grids(c=c, baseline=False, forecast=False))) == 0
 
 
 def test_workflow_grids_baseline(c, n_grids, noop):
     with patch.object(workflow, "_grid_grib", noop):
-        assert len(refs(workflow.grids_baseline(c=c))) == n_grids * 2
+        assert len(ref(workflow.grids_baseline(c=c))) == n_grids * 2
 
 
 def test_workflow_grids_forecast(c, n_grids, noop):
     with patch.object(workflow, "_grid_nc", noop):
-        assert len(refs(workflow.grids_forecast(c=c))) == n_grids
+        assert len(ref(workflow.grids_forecast(c=c))) == n_grids
 
 
 def test_workflow_plots(c, noop):
     cycles = gen_cycles(start=c.cycles.start, step=c.cycles.step, stop=c.cycles.stop)
     with patch.object(workflow, "_plot", noop):
         val = workflow.plots(c=c)
-    assert len(refs(val)) == len(cycles) * sum(
+    assert len(ref(val)) == len(cycles) * sum(
         len(list(workflow._stats_and_widths(c, varname)))
         for varname, _ in workflow._varnames_and_levels(c)
     )
@@ -110,7 +110,7 @@ def test_workflow_plots(c, noop):
 def test_workflow_stats(c, noop):
     with patch.object(workflow, "_statreqs", return_value=[noop()]) as _statreqs:
         val = workflow.stats(c=c)
-    assert len(refs(val)) == len(c.variables) + 1  # for 2x SPFH levels
+    assert len(ref(val)) == len(c.variables) + 1  # for 2x SPFH levels
 
 
 def test_workflow__existing(fakefs):
@@ -127,7 +127,7 @@ def test_workflow__forecast_dataset(da_with_leadtime, fakefs):
     with patch.object(workflow.xr, "open_dataset", return_value=da_with_leadtime.to_dataset()):
         val = workflow._forecast_dataset(path=path)
     assert ready(val)
-    assert (da_with_leadtime == refs(val).HGT).all()
+    assert (da_with_leadtime == ref(val).HGT).all()
 
 
 def test_workflow__grib_index_data(c, tc):
@@ -148,7 +148,7 @@ def test_workflow__grib_index_data(c, tc):
         val = workflow._grib_index_data(
             c=c, outdir=c.paths.grids_baseline, tc=tc, url=c.baseline.template
         )
-    assert refs(val) == {
+    assert ref(val) == {
         "gh-isobaricInhPa-0900": variables.HRRR(
             name="HGT", levstr="900 mb", firstbyte=0, lastbyte=0
         )
@@ -158,7 +158,7 @@ def test_workflow__grib_index_data(c, tc):
 def test_workflow__grib_index_file(c):
     url = f"{c.baseline.template}.idx"
     val = workflow._grib_index_file(outdir=c.paths.grids_baseline, url=url)
-    path: Path = refs(val)
+    path: Path = ref(val)
     assert not path.exists()
     path.parent.mkdir(parents=True, exist_ok=True)
     with patch.object(workflow, "fetch") as fetch:
@@ -187,7 +187,7 @@ def test_workflow__grid_grib(c, tc):
     var = variables.Var(name="t", level_type="isobaricInhPa", level=900)
     with patch.object(workflow, "_grib_index_data", wraps=mock) as _grib_index_data:
         val = workflow._grid_grib(c=c, tc=tc, var=var)
-        path = refs(val)
+        path = ref(val)
         assert not path.exists()
         ready.set()
         with patch.object(workflow, "fetch") as fetch:
@@ -211,7 +211,7 @@ def test_workflow__grid_nc(c_real_fs, check_cf_metadata, da_with_leadtime, tc):
     object.__setattr__(c_real_fs.forecast, "path", path)
     val = workflow._grid_nc(c=c_real_fs, varname="HGT", tc=tc, var=var)
     assert ready(val)
-    check_cf_metadata(ds=xr.open_dataset(refs(val), decode_timedelta=True), name="HGT", level=level)
+    check_cf_metadata(ds=xr.open_dataset(ref(val), decode_timedelta=True), name="HGT", level=level)
 
 
 def test_workflow__polyfile(fakefs):
@@ -251,7 +251,7 @@ def test_workflow__plot(c, dictkey, fakefs, fs):
         val = workflow._plot(
             c=c, varname=varname, level=level, cycle=cycles[0], stat=stat, width=width
         )
-    path = val.refs
+    path = val.ref
     assert ready(val)
     assert path.is_file()
     assert _prepare_plot_data.call_count == 1
@@ -268,7 +268,7 @@ def test_workflow__stat(c, fakefs, tc):
     taskname = "MET stats for baseline 2t-heightAboveGround-0002 at 19700101 00Z 000"
     var = variables.Var(name="2t", level_type="heightAboveGround", level=2)
     kwargs = dict(c=c, varname="T2M", tc=tc, var=var, prefix="foo", source=Source.BASELINE)
-    stat = refs(workflow._stat(**kwargs, dry_run=True))
+    stat = ref(workflow._stat(**kwargs, dry_run=True))
     cfgfile = (rundir / stat.stem).with_suffix(".config")
     runscript = (rundir / stat.stem).with_suffix(".sh")
     assert not stat.is_file()
@@ -318,7 +318,7 @@ def test__prepare_plot_data(dictkey):
     varname, level, dfs, stat, width = TESTDATA[dictkey]
     reqs = cast(Sequence[Node], ["node1", "node2"])
     with (
-        patch("iotaa.refs", side_effect=lambda x: f"{x}.stat"),
+        patch("iotaa.ref", side_effect=lambda x: f"{x}.stat"),
         patch("wxvx.workflow.pd.read_csv", side_effect=dfs),
     ):
         tdf = workflow._prepare_plot_data(reqs=reqs, stat=stat, width=width)

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 import xarray as xr
-from iotaa import Node, asset, external, refs, task, tasks
+from iotaa import Node, asset, external, ref, task, tasks
 
 from wxvx import variables
 from wxvx.metconf import render
@@ -126,7 +126,7 @@ def _grib_index_data(c: Config, outdir: Path, tc: TimeCoords, url: str):
     yield asset(idxdata, lambda: bool(idxdata))
     idxfile = _grib_index_file(outdir, url)
     yield idxfile
-    lines = idxfile.refs.read_text(encoding="utf-8").strip().split("\n")
+    lines = idxfile.ref.read_text(encoding="utf-8").strip().split("\n")
     lines.append(":-1:::::")  # end marker
     vxvars = set(_vxvars(c).keys())
     baseline_class = variables.model_class(c.baseline.name)
@@ -163,7 +163,7 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
     url = c.baseline.template.format(yyyymmdd=yyyymmdd, hh=hh, fh=int(leadtime))
     idxdata = _grib_index_data(c, outdir, tc, url=f"{url}.idx")
     yield idxdata
-    var_idxdata = idxdata.refs[str(var)]
+    var_idxdata = idxdata.ref[str(var)]
     fb, lb = var_idxdata.firstbyte, var_idxdata.lastbyte
     headers = {"Range": "bytes=%s" % (f"{fb}-{lb}" if lb else fb)}
     with atomic(path) as tmp:
@@ -179,7 +179,7 @@ def _grid_nc(c: Config, varname: str, tc: TimeCoords, var: Var):
     yield asset(path, path.is_file)
     fd = _forecast_dataset(c.forecast.path)
     yield fd
-    src = da_select(c, fd.refs, varname, tc, var)
+    src = da_select(c, fd.ref, varname, tc, var)
     da = da_construct(c, src)
     ds = ds_construct(c, da, taskname, var.level)
     with atomic(path) as tmp:
@@ -264,7 +264,7 @@ def _stat(c: Config, varname: str, tc: TimeCoords, var: Var, prefix: str, source
     runscript = path.with_suffix(".sh")
     content = f"""
     export OMP_NUM_THREADS=1
-    grid_stat -v 4 {toverify.refs} {baseline.refs} {cfgfile} >{log} 2>&1
+    grid_stat -v 4 {toverify.ref} {baseline.ref} {cfgfile} >{log} 2>&1
     """
     with atomic(runscript) as tmp:
         tmp.write_text("#!/usr/bin/env bash\n\n%s\n" % dedent(content).strip())
@@ -302,7 +302,7 @@ def _grid_stat_config(
         for x in field_fcst, field_obs:
             x["cnt_thresh"] = meta.cnt_thresh
     mask_grid = [] if polyfile else ["FULL"]
-    mask_poly = [polyfile.refs] if polyfile else []
+    mask_poly = [polyfile.ref] if polyfile else []
     config = {
         "fcst": {"field": [field_fcst]},
         "mask": {"grid": mask_grid, "poly": mask_poly},
@@ -327,7 +327,7 @@ def _meta(c: Config, varname: str) -> VarMeta:
 
 def _prepare_plot_data(reqs: Sequence[Node], stat: str, width: int | None) -> pd.DataFrame:
     linetype = LINETYPE[stat]
-    files = [str(refs(x)).replace(".stat", f"_{linetype}.txt") for x in reqs]
+    files = [str(ref(x)).replace(".stat", f"_{linetype}.txt") for x in reqs]
     columns = ["MODEL", "FCST_LEAD", stat]
     if linetype in ["cts", "nbrcnt"]:
         columns.append("FCST_THRESH")

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
 import xarray as xr
-from iotaa import Node, asset, external, ref, task, tasks
+from iotaa import Node, asset, external, task, tasks
 
 from wxvx import variables
 from wxvx.metconf import render
@@ -327,7 +327,7 @@ def _meta(c: Config, varname: str) -> VarMeta:
 
 def _prepare_plot_data(reqs: Sequence[Node], stat: str, width: int | None) -> pd.DataFrame:
     linetype = LINETYPE[stat]
-    files = [str(ref(x)).replace(".stat", f"_{linetype}.txt") for x in reqs]
+    files = [str(x.ref).replace(".stat", f"_{linetype}.txt") for x in reqs]
     columns = ["MODEL", "FCST_LEAD", stat]
     if linetype in ["cts", "nbrcnt"]:
         columns.append("FCST_THRESH")


### PR DESCRIPTION
1. Use the `.ref` (was `.refs` in `iotaa` `<1.3.0`) property on task `Node` objects instead of the `ref()` (was `refs()` in `iotaa` `<1.3.0`) function. The property is more concise and eliminates an import.

2. Use `ref` instead of `refs` terminology, available in `iotaa` `1.3.0`. The singular `ref` reads more naturally: If a task `t` has a single, scalar asset, its ref can now be accessed as `t.ref` instead of `t.refs`, where the plural was misleading. If `t` has a `list` of assets, they can be accessed as `t.ref[0]`, `t.ref[1]`, etc. (i.e. "ref 0", "ref 1", etc.). If `t` has a `dict` of assets, they can be accessed as `t.ref["foo"]`, `t.ref["bar"]`, etc. (i.e. "the foo ref", "the bar ref"). The plural `.refs` and `refs()` are still available in `iotaa` `>=1.3.0`, but emit a deprecation warning.

`iotaa` `1.3.0` (and `uwtools` `2.8.0`, which is also needed) are both currently pre-release, but will be released soon. In the meantime, pre-release packages are available in the `paul.madden` channel.
