### PR TITLE
Parameterized forecast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ An overview of the content of the YAML configuration file specified via `-c` / `
 
 ### baseline.url
 
-The `baseline.url` value may include Jinja2 expressions involving `wxvx`-supplied  variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`). The expressions will be processed, the variables replaced with appropriate values at run time.
+The `baseline.url` value may include Python string-template expressions, processed at run-time with [`str.format()`](https://docs.python.org/3/library/stdtypes.html#str.format). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`.
 
 ### cycles
 
@@ -112,7 +112,7 @@ The `forecast.mask` value may be omitted, or set to the YAML value `null`, in wh
 
 ### forecast.path
 
-The `forecast.path` value may include Jinja2 expressions involving `wxvx`-supplied  variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`). The expressions will be processed, the variables replaced with appropriate values at run time.
+The `forecast.path` value may include Python string-template expressions, processed at run-time with [`str.format()`](https://docs.python.org/3/library/stdtypes.html#str.format). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`.
 
 ### leadtimes
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ An overview of the content of the YAML configuration file specified via `-c` / `
 │ baseline:          │ Description of the baseline dataset       │
 │   compare:         │   Verify and/or plot forecast?            │
 │   name:            │   Dataset descriptive name                │
-│   template:        │   Template for baseline GRIB file URLs    │
+│   url:             │   Template for baseline GRIB file URLs    │
 │ cycles:            │ Cycles to verify                          │
 │   start:           │   First cycle                             │
 │   step:            │   Interval between cycles                 │
@@ -71,9 +71,9 @@ An overview of the content of the YAML configuration file specified via `-c` / `
 └────────────────────┴───────────────────────────────────────────┘
 ```
 
-### baseline.template
+### baseline.url
 
-The `baseline.template` value may include Jinja2 expressions involving `wxvx`-supplied  variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`). The expressions will be processed, the variables replaced with appropriate values at run time.
+The `baseline.url` value may include Jinja2 expressions involving `wxvx`-supplied  variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`). The expressions will be processed, the variables replaced with appropriate values at run time.
 
 ### cycles
 
@@ -195,7 +195,7 @@ Consider a `config.yaml`
 baseline:
   compare: true
   name: HRRR
-  template: https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.{yyyymmdd}/conus/hrrr.t{hh}z.wrfprsf{fh:02}.grib2
+  url: https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.{yyyymmdd}/conus/hrrr.t{hh}z.wrfprsf{fh:02}.grib2
 cycles:
   start: 2025-03-01T00:00:00
   step: 1
@@ -255,7 +255,7 @@ Verification will be limited to points within the bounding box given by `mask`.
 
 The forecast will be called `ML` in MET `.stat` files and in plots.
 
-It will be verified against `HRRR` analysis, which can be found in GRIB files in an AWS bucket at URLs given as the `baseline.template` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
+It will be verified against `HRRR` analysis, which can be found in GRIB files in an AWS bucket at URLs given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
 
 24 1-hourly cycles starting at 2025-03-01 00Z, each with forecast leadtimes 3, 6, and 9, will be verified.
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ An overview of the content of the YAML configuration file specified via `-c` / `
 └────────────────────┴───────────────────────────────────────────┘
 ```
 
-### baseline
+### baseline.template
 
-The `baseline` URL template may include `{yyyymmdd}` (cycle date), `{hh}` (cycle time), and `{fh}` (forecast hour, aka leadtime) Jinja2 expressions, which will be replaced with appropriate values at run time. `yyyymmdd` and `hh` are Python `str` values, and `fh` is an `int`.
+The `baseline.template` value may include Jinja2 expressions involving `wxvx`-supplied  variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`). The expressions will be processed, the variables replaced with appropriate values at run time.
 
 ### cycles
 
@@ -109,6 +109,10 @@ If a `forecast.coords.time` specifies the name of a coordinate dimension variabl
 ### forecast.mask
 
 The `forecast.mask` value may be omitted, or set to the YAML value `null`, in which case no masking will be applied.
+
+### forecast.path
+
+The `forecast.path` value may include Jinja2 expressions involving `wxvx`-supplied  variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`). The expressions will be processed, the variables replaced with appropriate values at run time.
 
 ### leadtimes
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A workflow tool for weather-model verification, leveraging [`uwtools`](https://g
 1. Download, install, and activate [Miniforge](https://github.com/conda-forge/miniforge), the [conda-forge](https://conda-forge.org/) project's implementation of [Miniconda](https://docs.anaconda.com/miniconda/). This step can be skipped if you already have a conda installation you want to use. Linux `aarch64` and `x86_64` systems are currently supported. The example shown below is for a Linux `aarch64` system, so if your system is Intel/AMD, download the `x86_64` installer.
 
 ``` bash
-wget https://github.com/conda-forge/miniforge/releases/download/24.11.3-0/Miniforge3-Linux-aarch64.sh
+wget https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-Linux-aarch64.sh
 bash Miniforge3-Linux-aarch64.sh -bfp conda
 rm Miniforge3-Linux-aarch64.sh
 . conda/etc/profile.d/conda.sh

--- a/src/wxvx/resources/config.jsonschema
+++ b/src/wxvx/resources/config.jsonschema
@@ -34,14 +34,14 @@
         "name": {
           "type": "string"
         },
-        "template": {
+        "url": {
           "type": "string"
         }
       },
       "required": [
         "compare",
         "name",
-        "template"
+        "url"
       ],
       "type": "object"
     },

--- a/src/wxvx/resources/config.yaml
+++ b/src/wxvx/resources/config.yaml
@@ -1,7 +1,7 @@
 baseline:
   compare: false
   name: HRRR
-  template: https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.{yyyymmdd}/conus/hrrr.t{hh}z.wrfprsf{fh:02}.grib2
+  url: https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.{yyyymmdd}/conus/hrrr.t{hh}z.wrfprsf{fh:02}.grib2
 cycles:
   start: 2024-04-01T02:00:00
   step: 1

--- a/src/wxvx/tests/conftest.py
+++ b/src/wxvx/tests/conftest.py
@@ -76,7 +76,7 @@ def config_data():
                 [21.138123, 225.90452027],
             ],
             "name": "Forecast",
-            "path": "/path/to/forecast",
+            "path": "/path/to/forecast-{yyyymmdd}-{hh}-{fh:03}.nc",
             "projection": {
                 "a": 6371229,
                 "b": 6371229,

--- a/src/wxvx/tests/conftest.py
+++ b/src/wxvx/tests/conftest.py
@@ -52,7 +52,7 @@ def config_data():
         "baseline": {
             "compare": True,
             "name": "GFS",
-            "template": "https://some.url/{yyyymmdd}/{hh}/{fh:02}/a.grib2",
+            "url": "https://some.url/{yyyymmdd}/{hh}/{fh:02}/a.grib2",
         },
         "cycles": {
             "start": "2024-12-19T18:00:00",

--- a/src/wxvx/tests/test_schema.py
+++ b/src/wxvx/tests/test_schema.py
@@ -67,7 +67,7 @@ def test_schema_baseline(logged, config_data, fs):
     # Basic correctness:
     assert ok(config)
     # Certain top-level keys are required:
-    for key in ["compare", "name", "template"]:
+    for key in ["compare", "name", "url"]:
         assert not ok(with_del(config, key))
         assert logged(f"'{key}' is a required property")
     # Additional keys are not allowed:
@@ -78,7 +78,7 @@ def test_schema_baseline(logged, config_data, fs):
         assert not ok(with_set(config, None, key))
         assert logged("None is not of type 'boolean'")
     # Some keys have string values:
-    for key in ["name", "template"]:
+    for key in ["name", "url"]:
         assert not ok(with_set(config, None, key))
         assert logged("None is not of type 'string'")
 

--- a/src/wxvx/tests/test_types.py
+++ b/src/wxvx/tests/test_types.py
@@ -118,7 +118,7 @@ def test_Forecast(config_data, forecast):
     assert obj.coords.time.inittime == "time"
     assert obj.coords.time.leadtime == "lead_time"
     assert obj.name == "Forecast"
-    assert obj.path == Path("/path/to/forecast")
+    assert obj.path == "/path/to/forecast"
     cfg = config_data["forecast"]
     other1 = types.Forecast(**cfg)
     assert obj == other1

--- a/src/wxvx/tests/test_types.py
+++ b/src/wxvx/tests/test_types.py
@@ -45,7 +45,7 @@ def time(config_data):
 def test_Baseline(baseline, config_data):
     obj = baseline
     assert obj.name == "GFS"
-    assert obj.template == "https://some.url/{yyyymmdd}/{hh}/{fh:02}/a.grib2"
+    assert obj.url == "https://some.url/{yyyymmdd}/{hh}/{fh:02}/a.grib2"
     cfg = config_data["baseline"]
     other1 = types.Baseline(**cfg)
     assert obj == other1

--- a/src/wxvx/tests/test_types.py
+++ b/src/wxvx/tests/test_types.py
@@ -118,7 +118,7 @@ def test_Forecast(config_data, forecast):
     assert obj.coords.time.inittime == "time"
     assert obj.coords.time.leadtime == "lead_time"
     assert obj.name == "Forecast"
-    assert obj.path == "/path/to/forecast"
+    assert obj.path == "/path/to/forecast-{yyyymmdd}-{hh}-{fh:03}.nc"
     cfg = config_data["forecast"]
     other1 = types.Forecast(**cfg)
     assert obj == other1

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -207,7 +207,7 @@ def test_workflow__grid_nc(c_real_fs, check_cf_metadata, da_with_leadtime, tc):
     var = variables.Var(name="gh", level_type="isobaricInhPa", level=level)
     path = Path(c_real_fs.paths.grids_forecast, "a.nc")
     da_with_leadtime.to_netcdf(path)
-    object.__setattr__(c_real_fs.forecast, "path", path)
+    object.__setattr__(c_real_fs.forecast, "path", str(path))
     val = workflow._grid_nc(c=c_real_fs, varname="HGT", tc=tc, var=var)
     assert ready(val)
     check_cf_metadata(ds=xr.open_dataset(val.ref, decode_timedelta=True), name="HGT", level=level)

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -145,7 +145,7 @@ def test_workflow__grib_index_data(c, tc):
 
     with patch.object(workflow, "_grib_index_file", mock):
         val = workflow._grib_index_data(
-            c=c, outdir=c.paths.grids_baseline, tc=tc, url=c.baseline.template
+            c=c, outdir=c.paths.grids_baseline, tc=tc, url=c.baseline.url
         )
     assert val.ref == {
         "gh-isobaricInhPa-0900": variables.HRRR(
@@ -155,7 +155,7 @@ def test_workflow__grib_index_data(c, tc):
 
 
 def test_workflow__grib_index_file(c):
-    url = f"{c.baseline.template}.idx"
+    url = f"{c.baseline.url}.idx"
     val = workflow._grib_index_file(outdir=c.paths.grids_baseline, url=url)
     path: Path = val.ref
     assert not path.exists()

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -21,7 +21,7 @@ Source = Enum("Source", [("BASELINE", auto()), ("FORECAST", auto())])
 class Baseline:
     compare: bool
     name: str
-    template: str
+    url: str
 
 
 class Config:

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -93,7 +93,7 @@ class Cycles:
 class Forecast:
     coords: Coords
     name: str
-    path: Path
+    path: str
     projection: dict
     mask: tuple[tuple[float, float]] | None = None
 
@@ -108,7 +108,6 @@ class Forecast:
             _force(self, "coords", coords)
         if self.mask:
             _force(self, "mask", tuple(tuple(x) for x in self.mask))
-        _force(self, "path", Path(self.path))
 
 
 class Leadtimes:

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 @tasks
 def grids(c: Config, baseline: bool = True, forecast: bool = True):
-    taskname = "Grids for %s" % c.forecast.path
+    taskname = "Grids for %s vs %s" % (c.forecast.name, c.baseline.name)
     yield taskname
     reqs: list[Node] = []
     for var, varname in _vxvars(c).items():
@@ -58,21 +58,21 @@ def grids(c: Config, baseline: bool = True, forecast: bool = True):
 
 @tasks
 def grids_baseline(c: Config):
-    taskname = "Baseline grids for %s" % c.forecast.path
+    taskname = "Baseline grids for %s" % c.baseline.name
     yield taskname
     yield grids(c, baseline=True, forecast=False)
 
 
 @tasks
 def grids_forecast(c: Config):
-    taskname = "Forecast grids for %s" % c.forecast.path
+    taskname = "Forecast grids for %s" % c.forecast.name
     yield taskname
     yield grids(c, baseline=False, forecast=True)
 
 
 @tasks
 def plots(c: Config):
-    taskname = "Plots for %s" % c.forecast.path
+    taskname = "Plots for %s vs %s" % (c.forecast.name, c.baseline.name)
     yield taskname
     yield [
         _plot(c, cycle, varname, level, stat, width)
@@ -84,7 +84,7 @@ def plots(c: Config):
 
 @tasks
 def stats(c: Config):
-    taskname = "Stats for %s" % c.forecast.path
+    taskname = "Stats for %s vs %s" % (c.forecast.name, c.baseline.name)
     yield taskname
     reqs: list[Node] = []
     for varname, level in _varnames_and_levels(c):
@@ -177,7 +177,7 @@ def _grid_nc(c: Config, varname: str, tc: TimeCoords, var: Var):
     taskname = "Forecast grid %s" % path
     yield taskname
     yield asset(path, path.is_file)
-    fd = _forecast_dataset(c.forecast.path)
+    fd = _forecast_dataset(Path(c.forecast.path.format(yyyymmdd=yyyymmdd, hh=hh, fh=int(leadtime))))
     yield fd
     src = da_select(c, fd.ref, varname, tc, var)
     da = da_construct(c, src)

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -160,7 +160,7 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
     taskname = "Baseline grid %s" % path
     yield taskname
     yield asset(path, path.is_file)
-    url = c.baseline.template.format(yyyymmdd=yyyymmdd, hh=hh, fh=int(leadtime))
+    url = c.baseline.url.format(yyyymmdd=yyyymmdd, hh=hh, fh=int(leadtime))
     idxdata = _grib_index_data(c, outdir, tc, url=f"{url}.idx")
     yield idxdata
     var_idxdata = idxdata.ref[str(var)]

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -39,7 +39,13 @@ if TYPE_CHECKING:
 
 @tasks
 def grids(c: Config, baseline: bool = True, forecast: bool = True):
-    taskname = "Grids for %s vs %s" % (c.forecast.name, c.baseline.name)
+    if baseline and not forecast:
+        suffix = "{b}"
+    elif forecast and not baseline:
+        suffix = "{f}"
+    else:
+        suffix = "{f} vs {b}"
+    taskname = "Grids for %s" % suffix.format(b=c.baseline.name, f=c.forecast.name)
     yield taskname
     reqs: list[Node] = []
     for var, varname in _vxvars(c).items():


### PR DESCRIPTION
- Rename `baseline.template` -> `baseline.url`. The fact that the value is a template is incidental, and it could be a URL with no template expressions.
- Support `{yyyymmdd}`, `{hh}`, and `{fh}` expressions in the `forecast.path` config value in the same way they're supported for `baseline.url`.

This permits forecast data to be provided in e.g. multiple netCDF files, provided that their paths/names are named in a way that reflects their cycle and leadtime values. For example, I'm currently working with an ML forecast dataset distributed as one netCDF file per cycle, e.g.
```
GRAP_v100_GFS_2025010100_f000_f240_06.nc
GRAP_v100_GFS_2025010112_f000_f240_06.nc
```
for the 00Z and 12Z cycles on 2025-01-01. These could now be referenced in a single `wxvx` run with the config entry
```
forecast:
  path: /path/to/GRAP_v100_GFS_{yyyymmdd}{hh}_f000_f240_06.nc
```
