### PR TITLE
Support finding baseline data on local filesystem paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ An overview of the content of the YAML configuration file specified via `-c` / `
 │ baseline:          │ Description of the baseline dataset       │
 │   compare:         │   Verify and/or plot forecast?            │
 │   name:            │   Dataset descriptive name                │
-│   url:             │   Template for baseline GRIB file URLs    │
+│   url:             │   Template for baseline GRIB location     │
 │ cycles:            │ Cycles to verify                          │
 │   start:           │   First cycle                             │
 │   step:            │   Interval between cycles                 │
@@ -268,7 +268,7 @@ Verification will be limited to points within the bounding box given by `mask`.
 
 The forecast will be called `ML` in MET `.stat` files and in plots.
 
-It will be verified against `HRRR` analysis, which can be found in GRIB files in an AWS bucket at URLs given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
+It will be verified against `HRRR` analysis, which can be found in GRIB files located either remotely (e.g. in an AWS bucket) or locally (either file:// URL or plain filesystem path), given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
 
 24 1-hourly cycles starting at 2025-03-01 00Z, each with forecast leadtimes 3, 6, and 9, will be verified.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Verification will be limited to points within the bounding box given by `mask`.
 
 The forecast will be called `ML` in MET `.stat` files and in plots.
 
-It will be verified against `HRRR` analysis, which can be found in GRIB files located either remotely (e.g. in an AWS bucket) or locally (either `file://` URL or plain filesystem path), given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
+It will be verified against `HRRR` analysis, which can be found in GRIB files located either remotely (e.g. in an AWS bucket) or locally (via `file://` URL or plain filesystem path), given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
 
 24 1-hourly cycles starting at 2025-03-01 00Z, each with forecast leadtimes 3, 6, and 9, will be verified.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Verification will be limited to points within the bounding box given by `mask`.
 
 The forecast will be called `ML` in MET `.stat` files and in plots.
 
-It will be verified against `HRRR` analysis, which can be found in GRIB files located either remotely (e.g. in an AWS bucket) or locally (via `file://` URL or plain filesystem path), given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
+It will be verified against `HRRR` analysis, which can be found in GRIB files located either remotely (e.g. in an AWS bucket) or locally (via `file://` URLs or plain filesystem paths), given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
 
 24 1-hourly cycles starting at 2025-03-01 00Z, each with forecast leadtimes 3, 6, and 9, will be verified.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Verification will be limited to points within the bounding box given by `mask`.
 
 The forecast will be called `ML` in MET `.stat` files and in plots.
 
-It will be verified against `HRRR` analysis, which can be found in GRIB files located either remotely (e.g. in an AWS bucket) or locally (either file:// URL or plain filesystem path), given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
+It will be verified against `HRRR` analysis, which can be found in GRIB files located either remotely (e.g. in an AWS bucket) or locally (either `file://` URL or plain filesystem path), given as the `baseline.url` value, where `yyyymmdd`, `hh`, and `fh` will be filled in by `wxvx`. (The `yyyymmdd` and `hh` values are strings like `20250523` and `06`, while `fh` is an `int` value to be formatted as needed.)
 
 24 1-hourly cycles starting at 2025-03-01 00Z, each with forecast leadtimes 3, 6, and 9, will be verified.
 

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -249,13 +249,6 @@ def test_workflow__grid_nc(c_real_fs, check_cf_metadata, da_with_leadtime, tc):
     check_cf_metadata(ds=xr.open_dataset(val.ref, decode_timedelta=True), name="HGT", level=level)
 
 
-def test_workflow__local_grib(tmp_path):
-    grib_path = tmp_path / "test.grib2"
-    assert not ready(workflow._local_grib(path=grib_path))
-    grib_path.write_text("foo")
-    assert ready(workflow._local_grib(path=grib_path))
-
-
 def test_workflow__polyfile(fakefs):
     path = fakefs / "a.poly"
     assert not path.is_file()

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -173,7 +173,7 @@ def test_workflow__grib_index_file(c):
 def test_workflow__grid_grib_local(template, config_data, gen_config, fakefs, tc):
     grib_path = fakefs / "gfs.t00z.pgrb2.0p25.f000"
     grib_path.write_text("foo")
-    config_data["baseline"]["url"] = template.format(root=fakefs, hh="00", fh=0)
+    config_data["baseline"]["url"] = template.format(root=fakefs)
     c = gen_config(config_data, fakefs)
     var = variables.Var(name="t", level_type="isobaricInhPa", level=900)
     val = workflow._grid_grib(c=c, tc=tc, var=var)

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -291,6 +291,16 @@ def test_workflow__plot(c, dictkey, fakefs, fs):
     xticks.assert_called_once_with(ticks=[0, 6, 12], labels=["000", "006", "012"], rotation=90)
 
 
+def test_workflow__remote_grib(tmp_path):
+    var = Var("t", "isobaricInhPa", 900)
+    idxdata = Mock(spec=Node)
+    idxdata.ref = {str(var): Mock(firstbyte=1, lastbyte=2)}
+    path = tmp_path / "out.grib2"
+    with patch.object(workflow, "fetch") as fetch:
+        workflow._remote_grib(idxdata, path, "task", "url", var)
+    fetch.assert_called_once_with("task", "url", path, {"Range": "bytes=1-2"})
+
+
 def test_workflow__stat(c, fakefs, tc):
     @external
     def mock(*_args, **_kwargs):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -369,8 +369,8 @@ def test_workflow__remote_grib(fakefs):
     idxdata = Mock(ref={str(var): Mock(firstbyte=1, lastbyte=2)})
     path = fakefs / "foo.grib2"
     with patch.object(workflow, "fetch") as fetch:
-        workflow._remote_grib(idxdata, path, "task", "url", var)
-    fetch.assert_called_once_with("task", "url", path, {"Range": "bytes=1-2"})
+        workflow._remote_grib(idxdata, path, "taskname", "url", var)
+    fetch.assert_called_once_with("taskname", "url", path, {"Range": "bytes=1-2"})
 
 
 @mark.parametrize("cycle", [datetime(2024, 12, 19, 18, tzinfo=timezone.utc), None])

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -309,14 +309,14 @@ def test_workflow__stat(c, fakefs, tc):
         ("{root}/gfs.t{hh}z.pgrb2.0p25.f{fh:03d}", "local"),
     ],
 )
-def test_workflow__classify_url(template, expected_scheme, tmp_path):
-    url = template.format(root=tmp_path.as_posix(), hh="00", fh=0)
+def test_workflow__classify_url(template, expected_scheme, fakefs):
+    url = template.format(root=fakefs, hh="00", fh=0)
     scheme, _ = workflow._classify_url(url)
     assert scheme == expected_scheme
 
 
-def test_workflow__classify_url_unsupported(tmp_path):
-    url = f"foo://{tmp_path.as_posix()}/gfs.t00z.pgrb2.0p25.f000"
+def test_workflow__classify_url_unsupported(fakefs):
+    url = f"foo://{fakefs}/gfs.t00z.pgrb2.0p25.f000"
     with raises(workflow.WXVXError) as e:
         workflow._classify_url(url)
     assert str(e.value) == f"Scheme 'foo' in '{url}' not supported."
@@ -364,10 +364,10 @@ def test_workflow__prepare_plot_data(dictkey):
         assert tdf["INTERP_PNTS"].eq(width**2).all()
 
 
-def test_workflow__remote_grib(tmp_path):
+def test_workflow__remote_grib(fakefs):
     var = Var("t", "isobaricInhPa", 900)
     idxdata = Mock(ref={str(var): Mock(firstbyte=1, lastbyte=2)})
-    path = tmp_path / "foo.grib2"
+    path = fakefs / "foo.grib2"
     with patch.object(workflow, "fetch") as fetch:
         workflow._remote_grib(idxdata, path, "task", "url", var)
     fetch.assert_called_once_with("task", "url", path, {"Range": "bytes=1-2"})

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -19,7 +19,7 @@ from pytest import fixture, mark, raises
 
 from wxvx import variables, workflow
 from wxvx.times import TimeCoords, gen_validtimes
-from wxvx.types import Source
+from wxvx.types import Proximity, Source
 from wxvx.variables import Var
 
 TESTDATA = {
@@ -304,9 +304,9 @@ def test_workflow__stat(c, fakefs, tc):
 @mark.parametrize(
     ("template", "expected_scheme"),
     [
-        ("http://link/to/gfs.t{hh}z.pgrb2.0p25.f{fh:03d}", "remote"),
-        ("file://{root}/gfs.t{hh}z.pgrb2.0p25.f{fh:03d}", "local"),
-        ("{root}/gfs.t{hh}z.pgrb2.0p25.f{fh:03d}", "local"),
+        ("http://link/to/gfs.t{hh}z.pgrb2.0p25.f{fh:03d}", Proximity.REMOTE),
+        ("file://{root}/gfs.t{hh}z.pgrb2.0p25.f{fh:03d}", Proximity.LOCAL),
+        ("{root}/gfs.t{hh}z.pgrb2.0p25.f{fh:03d}", Proximity.LOCAL),
     ],
 )
 def test_workflow__classify_url(template, expected_scheme, fakefs):
@@ -362,15 +362,6 @@ def test_workflow__prepare_plot_data(dictkey):
         assert width is not None
         assert "INTERP_PNTS" in tdf.columns
         assert tdf["INTERP_PNTS"].eq(width**2).all()
-
-
-def test_workflow__remote_grib(fakefs):
-    var = Var("t", "isobaricInhPa", 900)
-    idxdata = Mock(ref={str(var): Mock(firstbyte=1, lastbyte=2)})
-    path = fakefs / "foo.grib2"
-    with patch.object(workflow, "fetch") as fetch:
-        workflow._remote_grib(idxdata, path, "taskname", "url", var)
-    fetch.assert_called_once_with("taskname", "url", path, {"Range": "bytes=1-2"})
 
 
 @mark.parametrize("cycle", [datetime(2024, 12, 19, 18, tzinfo=timezone.utc), None])

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -14,6 +14,7 @@ _DatetimeT = str | datetime
 _TimedeltaT = str | int
 
 
+Proximity = Enum("Proximity", [("LOCAL", auto()), ("REMOTE", auto())])
 Source = Enum("Source", [("BASELINE", auto()), ("FORECAST", auto())])
 
 

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -174,11 +174,12 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
         idx = _grib_index_data(c, outdir, tc, url=f"{url}.idx")
         return taskname, path, idx, lambda: _remote_grib(idx, path, taskname, url, var)
 
-    taskname, asset_path, reqs, action = {"local": local, "remote": remote}[scheme]()
+    taskname, path, reqs, action = {"local": local, "remote": remote}[scheme]()
     yield taskname
-    yield asset(asset_path, asset_path.is_file)
+    yield asset(path, path.is_file)
     yield reqs
-    action and action()
+    if action:
+        action()
 
 
 @task

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -173,7 +173,7 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
 
     def remote():
         idx = _grib_index_data(c, outdir, tc, url=f"{url}.idx")
-        return path, idx, lambda: _remote_grib(idx, var, url, taskname, path)
+        return path, idx, lambda: _remote_grib(idx, path, taskname, url, var)
 
     asset_path, reqs, action = {
         "local": local,
@@ -367,7 +367,7 @@ def _prepare_plot_data(reqs: Sequence[Node], stat: str, width: int | None) -> pd
     return plot_data
 
 
-def _remote_grib(idxdata, var: Var, url: str, taskname: str, path: Path):
+def _remote_grib(idxdata: Node, path: Path, taskname: str, url: str, var: Var):
     var_idx = idxdata.ref[str(var)]
     fb, lb = var_idx.firstbyte, var_idx.lastbyte
     headers = {"Range": "bytes=%s" % (f"{fb}-{lb}" if lb else fb)}

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -173,7 +173,7 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
 
     def remote():
         idx = _grib_index_data(c, outdir, tc, url=f"{url}.idx")
-        return path, idx, lambda: remote_setup(idx, var, url, taskname, path)
+        return path, idx, lambda: _remote_grib(idx, var, url, taskname, path)
 
     asset_path, reqs, action = {
         "local": local,
@@ -367,7 +367,7 @@ def _prepare_plot_data(reqs: Sequence[Node], stat: str, width: int | None) -> pd
     return plot_data
 
 
-def remote_setup(idxdata, var: Var, url: str, taskname: str, path: Path):
+def _remote_grib(idxdata, var: Var, url: str, taskname: str, path: Path):
     var_idx = idxdata.ref[str(var)]
     fb, lb = var_idx.firstbyte, var_idx.lastbyte
     headers = {"Range": "bytes=%s" % (f"{fb}-{lb}" if lb else fb)}

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -169,13 +169,14 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
     if kind == "local":
         yield asset(Path(src), Path(src).is_file)
         yield _local_grib(Path(src))
-    yield asset(path, path.is_file)
-    idxdata = _grib_index_data(c, outdir, tc, url=f"{url}.idx")
-    yield idxdata
-    var_idxdata = idxdata.ref[str(var)]
-    fb, lb = var_idxdata.firstbyte, var_idxdata.lastbyte
-    headers = {"Range": "bytes=%s" % (f"{fb}-{lb}" if lb else fb)}
-    fetch(taskname, url, path, headers)
+    else:
+        yield asset(path, path.is_file)
+        idxdata = _grib_index_data(c, outdir, tc, url=f"{url}.idx")
+        yield idxdata
+        var_idxdata = idxdata.ref[str(var)]
+        fb, lb = var_idxdata.firstbyte, var_idxdata.lastbyte
+        headers = {"Range": "bytes=%s" % (f"{fb}-{lb}" if lb else fb)}
+        fetch(taskname, url, path, headers)
 
 
 @task
@@ -197,7 +198,8 @@ def _grid_nc(c: Config, varname: str, tc: TimeCoords, var: Var):
 
 @external
 def _local_grib(path: Path):
-    yield f"Existing local GRIB {path}"
+    taskname = "Existing local GRIB %s" % path
+    yield taskname
     yield asset(path, path.is_file)
 
 


### PR DESCRIPTION
Fixes #18. 

Timed `stats` runs after running `grids_baseline` (with 4 threads instead 8, because 8 failed with unavailable resource errors):

Local:
- 1 thread: 2:50.96
- 4 threads: 0:46.74

Remote:
- 1 thread: 2:17.50
- 4 threads: 0:39.79

The logging is rather underwhelming because it’s already ready, so running `grids_baseline` only gets you:
```
[2025-08-11T17:57:49]     INFO Schema validation succeeded for config
[2025-08-11T17:57:49]     INFO Preparing task graph for grids_baseline
[2025-08-11T17:57:49]     INFO Baseline grids for HRRR: Ready
```