### PR TITLE
Add runtime checks

### DIFF
--- a/src/wxvx/cli.py
+++ b/src/wxvx/cli.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import traceback
 from argparse import Action, ArgumentParser, HelpFormatter, Namespace
 from pathlib import Path
 from typing import NoReturn
@@ -34,6 +35,8 @@ def main() -> None:
             task = getattr(workflow, args.task)
             task(Config(config_data.data), threads=args.threads)
     except WXVXError as e:
+        for line in traceback.format_exc().strip().split("\n"):
+            logging.debug(line)
         fail(str(e))
 
 

--- a/src/wxvx/cli.py
+++ b/src/wxvx/cli.py
@@ -11,27 +11,30 @@ from uwtools.api.logging import use_uwtools_logger
 
 from wxvx import workflow
 from wxvx.types import Config
-from wxvx.util import fail, pkgname, resource, resource_path
+from wxvx.util import WXVXError, fail, pkgname, resource, resource_path
 
 # Public
 
 
 def main() -> None:
-    args = _parse_args(sys.argv)
-    use_uwtools_logger(verbose=args.debug)
-    if not args.task:
-        _show_tasks_and_exit(0)
-    if args.task not in tasknames(workflow):
-        logging.error("No such task: %s", args.task)
-        _show_tasks_and_exit(1)
-    config_data = get_yaml_config(args.config)
-    config_data.dereference()
-    if not validate(schema_file=resource_path("config.jsonschema"), config_data=config_data):
-        fail()
-    if not args.check:
-        logging.info("Preparing task graph for %s", args.task)
-        task = getattr(workflow, args.task)
-        task(Config(config_data.data), threads=args.threads)
+    try:
+        args = _parse_args(sys.argv)
+        use_uwtools_logger(verbose=args.debug)
+        if not args.task:
+            _show_tasks_and_exit(0)
+        if args.task not in tasknames(workflow):
+            logging.error("No such task: %s", args.task)
+            _show_tasks_and_exit(1)
+        config_data = get_yaml_config(args.config)
+        config_data.dereference()
+        if not validate(schema_file=resource_path("config.jsonschema"), config_data=config_data):
+            fail()
+        if not args.check:
+            logging.info("Preparing task graph for %s", args.task)
+            task = getattr(workflow, args.task)
+            task(Config(config_data.data), threads=args.threads)
+    except WXVXError as e:
+        fail(str(e))
 
 
 # Private

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -94,6 +94,13 @@ def test_workflow_grids_baseline(c, n_grids, noop):
         assert len(workflow.grids_baseline(c=c).ref) == n_grids * 2
 
 
+def test_workflow_grids_baseline__no_path(c):
+    c.paths = replace(c.paths, grids_baseline=None)
+    with raises(WXVXError) as e:
+        workflow.grids_baseline(c)
+    assert str(e.value) == "Baseline grids for GFS: Config value paths.grids.baseline is not set"
+
+
 def test_workflow_grids_forecast(c, n_grids, noop):
     with patch.object(workflow, "_grid_nc", noop):
         assert len(workflow.grids_forecast(c=c).ref) == n_grids
@@ -119,7 +126,7 @@ def test_workflow_obs__bad_baseline_type(c):
     c.baseline = replace(c.baseline, type="grid")
     with raises(WXVXError) as e:
         workflow.obs(c)
-    assert str(e.value) == "Baseline obs for GFS: Set baseline type to 'obs' (not 'grid')"
+    assert str(e.value) == "Baseline obs for GFS: Config value baseline.type should be set to 'obs'"
 
 
 def test_workflow_plots(c, noop):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -116,7 +116,7 @@ def test_workflow_obs(c):
 
 
 def test_workflow_obs__bad_baseline_type(c):
-    c.baseline = replace(c.baseline, type="grid")
+    c.baseline = replace(c.baseline, type=VxType.GRID)
     with raises(WXVXError) as e:
         workflow.obs(c)
     expected = "This task requires that config value baseline.type be set to 'obs'"

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -463,7 +463,7 @@ def test_workflow__grid_grib__remote(c, tc):
     _grib_index_data.assert_called_with(c, outdir, tc, url=url)
 
 
-def test_workflow__gird_grib__remote_no_path(c, tc):
+def test_workflow__grid_grib__remote_no_path(c, tc):
     c.paths = replace(c.paths, grids_baseline=None)
     with raises(WXVXError) as e:
         workflow._grid_grib(c=c, tc=tc, var=Var(name="t", level_type="isobaricInhPa", level=900))
@@ -513,6 +513,14 @@ def test_workflow__netcdf_from_obs(c, tc):
     runscript = cfgfile.with_suffix(".sh")
     assert runscript.is_file()
     mpexec.assert_called_once_with(str(runscript), ANY, ANY)
+
+
+def test_workflow__netcdf_from_obs__no_path(c, tc):
+    c.paths = replace(c.paths, obs=None)
+    with raises(WXVXError) as e:
+        workflow._netcdf_from_obs(c=c, tc=tc)
+    expected = "Config value paths.obs must be set"
+    assert expected in str(e.value)
 
 
 @mark.parametrize("dictkey", ["foo", "bar", "baz"])

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -98,7 +98,8 @@ def test_workflow_grids_baseline__no_path(c):
     c.paths = replace(c.paths, grids_baseline=None)
     with raises(WXVXError) as e:
         workflow.grids_baseline(c)
-    assert str(e.value) == "Baseline grids for GFS: Config value paths.grids.baseline is not set"
+    expected = "This task requires that config value paths.grids.baseline be set"
+    assert expected in str(e.value)
 
 
 def test_workflow_grids_forecast(c, n_grids, noop):
@@ -126,7 +127,8 @@ def test_workflow_obs__bad_baseline_type(c):
     c.baseline = replace(c.baseline, type="grid")
     with raises(WXVXError) as e:
         workflow.obs(c)
-    assert str(e.value) == "Baseline obs for GFS: Config value baseline.type should be set to 'obs'"
+    expected = "This task requires that config value baseline.type be set to 'obs'"
+    assert expected in str(e.value)
 
 
 def test_workflow_plots(c, noop):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -20,7 +20,7 @@ from pytest import fixture, mark, raises
 
 from wxvx import variables, workflow
 from wxvx.times import gen_validtimes, tcinfo
-from wxvx.types import Source, VxType
+from wxvx.types import Source
 from wxvx.util import WXVXError
 from wxvx.variables import Var
 
@@ -116,10 +116,10 @@ def test_workflow_obs(c):
 
 
 def test_workflow_obs__bad_baseline_type(c):
-    c.baseline = replace(c.baseline, type=VxType.GRID)
+    c.baseline = replace(c.baseline, type="grid")
     with raises(WXVXError) as e:
         workflow.obs(c)
-    expected = "This task requires that config value baseline.type be set to 'obs'"
+    expected = "This task requires that config value baseline.type be set to 'point'"
     assert expected in str(e.value)
 
 
@@ -498,7 +498,7 @@ def test_workflow__local_file_from_http(c):
 def test_workflow__netcdf_from_obs(c, tc):
     yyyymmdd, hh, _ = tcinfo(tc)
     url = "https://bucket.amazonaws.com/gdas.{{ yyyymmdd }}.t{{ hh }}z.prepbufr.nr"
-    c.baseline = replace(c.baseline, url=url)
+    c.baseline = replace(c.baseline, type="point", url=url)
     path = c.paths.obs / yyyymmdd / hh / f"gdas.{yyyymmdd}.t{hh}z.prepbufr.nc"
     assert not path.is_file()
     prepbufr = path.with_suffix(".nr")
@@ -603,7 +603,7 @@ def test_workflow__stats_vs_obs(c, fakefs, tc):
 
     taskfunc = workflow._stats_vs_obs
     url = "https://bucket.amazonaws.com/gdas.{{ yyyymmdd }}.t{{ hh }}z.prepbufr.nr"
-    c.baseline = replace(c.baseline, type=VxType.POINT, url=url)
+    c.baseline = replace(c.baseline, type="point", url=url)
     rundir = fakefs / "run" / "stats" / "19700101" / "00" / "000"
     taskname = "Stats vs obs for baseline 2t-heightAboveGround-0002 at 19700101 00Z 000"
     var = variables.Var(name="2t", level_type="heightAboveGround", level=2)

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -35,7 +35,7 @@ class Baseline:
     compare: bool
     name: str
     url: str
-    type: str
+    type: VxType
 
     def __post_init__(self):
         _force(self, "type", VxType.POINT if self.type == "point" else VxType.GRID)

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -38,7 +38,9 @@ class Baseline:
     type: VxType
 
     def __post_init__(self):
-        _force(self, "type", VxType.POINT if self.type == "point" else VxType.GRID)
+        assert self.type in ["grid", "point"]
+        newval = {"grid": VxType.GRID, "point": VxType.POINT}
+        _force(self, "type", newval.get(str(self.type), self.type))
 
 
 class Config:

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -342,10 +342,10 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
         yield asset(src, src.is_file)
         yield None
     else:
-        if not (basepath := c.paths.grids_baseline):
+        if not c.paths.grids_baseline:
             msg = "Config value paths.grids.baseline must be set"
             raise WXVXError(msg)
-        outdir = basepath / yyyymmdd / hh / leadtime
+        outdir = c.paths.grids_baseline / yyyymmdd / hh / leadtime
         path = outdir / f"{var}.grib2"
         taskname = "Baseline grid %s" % path
         yield taskname
@@ -391,6 +391,9 @@ def _netcdf_from_obs(c: Config, tc: TimeCoords):
     taskname = "netCDF from prepbufr at %s %sZ" % (yyyymmdd, hh)
     yield taskname
     url = render(c.baseline.url, tc)
+    if not c.paths.obs:
+        msg = "Config value paths.obs must be set"
+        raise WXVXError(msg)
     path = (c.paths.obs / yyyymmdd / hh / url.split("/")[-1]).with_suffix(".nc")
     yield asset(path, path.is_file)
     rundir = c.paths.run / "stats" / yyyymmdd / hh

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -65,6 +65,8 @@ def grids(c: Config, baseline: bool = True, forecast: bool = True):
 @tasks
 def grids_baseline(c: Config):
     taskname = "Baseline grids for %s" % c.baseline.name
+    if not c.paths.grids_baseline:
+        raise WXVXError("%s: Config value paths.grids.baseline is not set" % taskname)
     yield taskname
     yield grids(c, baseline=True, forecast=False)
 
@@ -80,7 +82,7 @@ def grids_forecast(c: Config):
 def obs(c: Config):
     taskname = "Baseline obs for %s" % c.baseline.name
     if c.baseline.type == VxType.GRID:
-        raise WXVXError("%s: Set baseline type to 'obs' (not 'grid')" % taskname)
+        raise WXVXError("%s: Config value baseline.type should be set to 'obs'" % taskname)
     yield taskname
     reqs = []
     for tc in gen_validtimes(c.cycles, c.leadtimes):

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -79,6 +79,8 @@ def grids_forecast(c: Config):
 @tasks
 def obs(c: Config):
     taskname = "Baseline obs for %s" % c.baseline.name
+    if c.baseline.type == VxType.GRID:
+        raise WXVXError("%s: Set baseline type to 'obs' (not 'grid')" % taskname)
     yield taskname
     reqs = []
     for tc in gen_validtimes(c.cycles, c.leadtimes):

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -80,7 +80,7 @@ def grids_forecast(c: Config):
 def obs(c: Config):
     taskname = "Baseline obs for %s" % c.baseline.name
     if c.baseline.type == VxType.GRID:
-        msg = "%s: This task requires that config value baseline.type be set to 'obs'"
+        msg = "%s: This task requires that config value baseline.type be set to 'point'"
         raise WXVXError(msg % taskname)
     yield taskname
     reqs = []

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -65,9 +65,6 @@ def grids(c: Config, baseline: bool = True, forecast: bool = True):
 @tasks
 def grids_baseline(c: Config):
     taskname = "Baseline grids for %s" % c.baseline.name
-    if not c.paths.grids_baseline:
-        msg = "%s: This task requires that config value paths.grids.baseline be set"
-        raise WXVXError(msg % taskname)
     yield taskname
     yield grids(c, baseline=True, forecast=False)
 
@@ -345,7 +342,10 @@ def _grid_grib(c: Config, tc: TimeCoords, var: Var):
         yield asset(src, src.is_file)
         yield None
     else:
-        outdir = c.paths.grids_baseline / yyyymmdd / hh / leadtime
+        if not (basepath := c.paths.grids_baseline):
+            msg = "Config value paths.grids.baseline must be set"
+            raise WXVXError(msg)
+        outdir = basepath / yyyymmdd / hh / leadtime
         path = outdir / f"{var}.grib2"
         taskname = "Baseline grid %s" % path
         yield taskname

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -66,7 +66,8 @@ def grids(c: Config, baseline: bool = True, forecast: bool = True):
 def grids_baseline(c: Config):
     taskname = "Baseline grids for %s" % c.baseline.name
     if not c.paths.grids_baseline:
-        raise WXVXError("%s: Config value paths.grids.baseline is not set" % taskname)
+        msg = "%s: This task requires that config value paths.grids.baseline be set"
+        raise WXVXError(msg % taskname)
     yield taskname
     yield grids(c, baseline=True, forecast=False)
 
@@ -82,7 +83,8 @@ def grids_forecast(c: Config):
 def obs(c: Config):
     taskname = "Baseline obs for %s" % c.baseline.name
     if c.baseline.type == VxType.GRID:
-        raise WXVXError("%s: Config value baseline.type should be set to 'obs'" % taskname)
+        msg = "%s: This task requires that config value baseline.type be set to 'obs'"
+        raise WXVXError(msg % taskname)
     yield taskname
     reqs = []
     for tc in gen_validtimes(c.cycles, c.leadtimes):


### PR DESCRIPTION
During testing, I ran into two issues:

1. Requesting `-t obs` when `baseline.type` was set to `grid` tried to download data, but the `obs` task should require that `baseline.type` be set to `point`.
2. If baseline grids are to be written, `paths.grids.baseline` must be set in the config.

This PR addresses these issues with run-time checks, backed up by unit tests, and tests that `paths.obs` is also set when it's needed.