### PR TITLE
Provide cycle and leadtime for baseline.url rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For `point`, `url` should point to prepbufr data, and `compare` and `name` shoul
 
 ### baseline.url
 
-The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
+The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` as needed, and compute valid time with `(cycle + leadtime)`.
 
 ### cycles
 
@@ -134,7 +134,7 @@ An arbitrary value identifying the forecast model being verified. This name will
 
 ### forecast.path
 
-The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
+The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` as needed, and compute valid time with `(cycle + leadtime)`.
 
 ### leadtimes
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For `point`, `url` should point to prepbufr data, and `compare` and `name` shoul
 
 ### baseline.url
 
-The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` to format date/time components (e.g., `'%Y%m%d'`, `'%H'`), and compute valid time with `(cycle + leadtime)`.
+The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a [`datetime`](https://docs.python.org/3/library/datetime.html#datetime-objects)) and `leadtime` (a [`timedelta`](https://docs.python.org/3/library/datetime.html#timedelta-objects)) are available for computing arbitrary time strings.
 
 ### cycles
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For `point`, `url` should point to prepbufr data, and `compare` and `name` shoul
 
 ### baseline.url
 
-The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`; additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
+The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
 
 ### cycles
 
@@ -134,7 +134,7 @@ An arbitrary value identifying the forecast model being verified. This name will
 
 ### forecast.path
 
-The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`; additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
+The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
 
 ### leadtimes
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For `point`, `url` should point to prepbufr data, and `compare` and `name` shoul
 
 ### baseline.url
 
-The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` as needed, and compute valid time with `(cycle + leadtime)`.
+The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` to format date/time components (e.g., `'%Y%m%d'`, `'%H'`), and compute valid time with `(cycle + leadtime)`.
 
 ### cycles
 
@@ -134,7 +134,7 @@ An arbitrary value identifying the forecast model being verified. This name will
 
 ### forecast.path
 
-The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` as needed, and compute valid time with `(cycle + leadtime)`.
+The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` to format date/time components (e.g., `'%Y%m%d'`, `'%H'`), and compute valid time with `(cycle + leadtime)`.
 
 ### leadtimes
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For `point`, `url` should point to prepbufr data, and `compare` and `name` shoul
 
 ### baseline.url
 
-The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
+The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
 
 ### cycles
 
@@ -134,7 +134,7 @@ An arbitrary value identifying the forecast model being verified. This name will
 
 ### forecast.path
 
-The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
+The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
 
 ### leadtimes
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For `point`, `url` should point to prepbufr data, and `compare` and `name` shoul
 
 ### baseline.url
 
-The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Tremplate.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`.
+The `baseline.url` value may include Jinja2 expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`; additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
 
 ### cycles
 
@@ -134,7 +134,7 @@ An arbitrary value identifying the forecast model being verified. This name will
 
 ### forecast.path
 
-The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Tremplate.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`.
+The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`; additionally, `cycle` (initialization time, a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime('%Y%m%d')` for dates; compute valid time with `(cycle + leadtime)`.
 
 ### leadtimes
 
@@ -154,7 +154,7 @@ leadtimes:
 or
 
 ``` yaml
-cycles: [3, 6, 9]
+leadtimes: [3, 6, 9]
 ```
 
 ### meta

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ An arbitrary value identifying the forecast model being verified. This name will
 
 ### forecast.path
 
-The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a `datetime`) and `leadtime` (a `timedelta`) are available. Use `cycle.strftime()` to format date/time components (e.g., `'%Y%m%d'`, `'%H'`), and compute valid time with `(cycle + leadtime)`.
+The `forecast.path` value may include Python string-template expressions, processed at run-time with [`jinja2.Template.render()`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.Template.render). Variables `yyyymmdd` (cycle date, a `str`), `hh` (cycle time, a `str`), and `fh` (forecast hour, aka leadtime, an `int`) will be supplied by `wxvx`. Additionally, `cycle` (a [`datetime`](https://docs.python.org/3/library/datetime.html#datetime-objects)) and `leadtime` (a [`timedelta`](https://docs.python.org/3/library/datetime.html#timedelta-objects)) are available for computing arbitrary time strings.
 
 ### leadtimes
 

--- a/src/wxvx/tests/test_util.py
+++ b/src/wxvx/tests/test_util.py
@@ -165,6 +165,8 @@ def test_util_render(utc):
     template = "{{ yyyymmdd }}-{{ yyyymmdd[:4] }}-{{ hh }}-{{ '%03d' % fh }}"
     tc = TimeCoords(cycle=utc(2025, 8, 21, 6), leadtime=1)
     assert util.render(template, tc) == "20250821-2025-06-001"
+    template = "{{ cycle.strftime('%Y%m%d') }}-{{ (cycle + leadtime).strftime('%H') }}"
+    assert util.render(template, tc) == "20250821-07"
 
 
 def test_util_resource(fs):

--- a/src/wxvx/tests/test_util.py
+++ b/src/wxvx/tests/test_util.py
@@ -165,7 +165,11 @@ def test_util_render(utc):
     template = "{{ yyyymmdd }}-{{ yyyymmdd[:4] }}-{{ hh }}-{{ '%03d' % fh }}"
     tc = TimeCoords(cycle=utc(2025, 8, 21, 6), leadtime=1)
     assert util.render(template, tc) == "20250821-2025-06-001"
+
+
+def test_util_render_with_cycle(utc):
     template = "{{ cycle.strftime('%Y%m%d') }}-{{ (cycle + leadtime).strftime('%H') }}"
+    tc = TimeCoords(cycle=utc(2025, 8, 21, 6), leadtime=1)
     assert util.render(template, tc) == "20250821-07"
 
 

--- a/src/wxvx/util.py
+++ b/src/wxvx/util.py
@@ -132,7 +132,9 @@ def mpexec(cmd: str, rundir: Path, taskname: str, env: dict | None = None) -> No
 
 def render(template: str, tc: TimeCoords) -> str:
     yyyymmdd, hh, leadtime = tcinfo(tc)
-    return jinja2.Template(template).render(yyyymmdd=yyyymmdd, hh=hh, fh=int(leadtime))
+    return jinja2.Template(template).render(
+        yyyymmdd=yyyymmdd, hh=hh, fh=int(leadtime), cycle=tc.cycle, leadtime=tc.leadtime
+    )
 
 
 def resource(relpath: str | Path) -> str:


### PR DESCRIPTION
Fixes #32.

Initially, I interpreted this ticket as replacing `yyyymmdd`, `hh`, and `fh` with `cycle` and `leadtime`, but that would be a breaking change for every config to date, so I've left those variables available, and added `cycle` and `leadtime` to preserve existing behavior. README, code, and tests updated. 