### PR TITLE
Support verification of GRIB-based forecast datasets

### DIFF
--- a/src/wxvx/cli.py
+++ b/src/wxvx/cli.py
@@ -64,7 +64,6 @@ def _parse_args(argv: list[str]) -> Namespace:
         "--task",
         help="Task to execute",
         metavar="TASK",
-        nargs="?",
         default=None,
     )
     optional = parser.add_argument_group("Optional arguments")

--- a/src/wxvx/cli.py
+++ b/src/wxvx/cli.py
@@ -127,7 +127,8 @@ def _process_args(args: Namespace) -> None:
     if args.check:
         return
     if args.task not in tasknames(workflow):
-        logging.error("No such task: %s", args.task)
+        msg = "No such task: %s" % args.task if args.task else "No task specified"
+        logging.error(msg)
         _show_tasks()
         sys.exit(1)
     return

--- a/src/wxvx/cli.py
+++ b/src/wxvx/cli.py
@@ -126,8 +126,7 @@ def _process_args(args: Namespace) -> None:
     if args.check:
         return
     if args.task not in tasknames(workflow):
-        msg = "No such task: %s" % args.task if args.task else "No task specified"
-        logging.error(msg)
+        logging.error("No such task: %s", args.task)
         _show_tasks()
         sys.exit(1)
     return

--- a/src/wxvx/metconf.py
+++ b/src/wxvx/metconf.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, NoReturn
 
+from wxvx.types import ToGridVal
+
 # Public:
 
 
@@ -157,7 +159,7 @@ def _regrid(k: str, v: Any, level: int) -> list[str]:
             return _kvpair(k, _bare(v), level)
         # Scalar: custom.
         case "to_grid":
-            f = _bare if v in ("FCST", "OBS") else _quoted
+            f = _bare if v in [x.name for x in ToGridVal] else _quoted
             return _kvpair(k, f(v), level)
     return _fail(k)
 

--- a/src/wxvx/resources/config.jsonschema
+++ b/src/wxvx/resources/config.jsonschema
@@ -238,10 +238,8 @@
         }
       },
       "required": [
-        "coords",
         "name",
-        "path",
-        "projection"
+        "path"
       ],
       "type": "object"
     },

--- a/src/wxvx/tests/conftest.py
+++ b/src/wxvx/tests/conftest.py
@@ -4,6 +4,7 @@ import logging
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from textwrap import dedent
 from typing import Callable
 
 import numpy as np
@@ -207,6 +208,11 @@ def tc(da_with_leadtime):
     cycle = datetime.fromtimestamp(int(da_with_leadtime.time.values[0]), tz=timezone.utc)
     leadtime = timedelta(hours=int(da_with_leadtime.lead_time.values[0]))
     return times.TimeCoords(cycle=cycle, leadtime=leadtime)
+
+
+@fixture
+def tidy(text: str) -> str:
+    return dedent(text).strip()
 
 
 @fixture

--- a/src/wxvx/tests/conftest.py
+++ b/src/wxvx/tests/conftest.py
@@ -211,8 +211,8 @@ def tc(da_with_leadtime):
 
 
 @fixture
-def tidy(text: str) -> str:
-    return dedent(text).strip()
+def tidy():
+    return lambda text: dedent(text).strip()
 
 
 @fixture

--- a/src/wxvx/tests/test_cli.py
+++ b/src/wxvx/tests/test_cli.py
@@ -5,7 +5,6 @@ Tests for wxvx.cli.
 import logging
 import re
 from pathlib import Path
-from textwrap import dedent
 from unittest.mock import DEFAULT as D
 from unittest.mock import patch
 
@@ -73,7 +72,7 @@ def test_cli_main__exception(logged):
     assert e.value.code == 1
 
 
-def test_cli_main__task_list(caplog):
+def test_cli_main__task_list(caplog, tidy):
     caplog.set_level(logging.INFO)
     with (
         patch.object(cli.sys, "argv", [pkgname, "-c", str(resource_path("config-grid.yaml"))]),
@@ -90,7 +89,7 @@ def test_cli_main__task_list(caplog):
           plots
           stats
         """
-        for line in dedent(expected).strip().split("\n"):
+        for line in tidy(expected).split("\n"):
             assert line in caplog.messages
 
 

--- a/src/wxvx/tests/test_cli.py
+++ b/src/wxvx/tests/test_cli.py
@@ -94,7 +94,7 @@ def test_cli_main__task_list(caplog, switch, tidy):
           plots
           stats
         """
-        assert re.sub(r"INFO     [^ ]+ ", "", caplog.text.strip()) == dedent(expected).strip()
+        assert re.sub(r"INFO     [^ ]+ ", "", caplog.text.strip()) == tidy(expected)
 
 
 def test_cli_main__task_missing(caplog):

--- a/src/wxvx/tests/test_metconf.py
+++ b/src/wxvx/tests/test_metconf.py
@@ -1,4 +1,3 @@
-from textwrap import dedent
 from typing import Callable
 
 from pytest import mark, raises
@@ -8,7 +7,7 @@ from wxvx import metconf
 # Public:
 
 
-def test_metconf_render():
+def test_metconf_render(tidy):
     config = {
         "fcst": {
             "field": [
@@ -180,7 +179,7 @@ def test_metconf_render():
     }
     tmp_dir = "/path/to/dir";
     """
-    expected = dedent(text).strip()
+    expected = tidy(text)
     assert metconf.render(config=config).strip() == expected
 
 
@@ -213,7 +212,7 @@ def test_metconf__fail():
         metconf._fail(k=key)
 
 
-def test_metconf__field_mapping():
+def test_metconf__field_mapping(tidy):
     text = """
     {
       cnt_thresh = [
@@ -226,7 +225,7 @@ def test_metconf__field_mapping():
       name = "foo";
     }
     """
-    expected = dedent(text).strip()
+    expected = tidy(text)
     assert (
         metconf._field_mapping(
             d={"name": "foo", "cnt_thresh": [1, 2], "level": ["(0,0,*,*)"]}, level=0
@@ -239,7 +238,7 @@ def test_metconf__field_mapping_kvpairs():
     _fail(metconf._field_mapping_kvpairs)
 
 
-def test_metconf__field_sequence():
+def test_metconf__field_sequence(tidy):
     text = """
     field = [
       {
@@ -264,7 +263,7 @@ def test_metconf__field_sequence():
       }
     ];
     """
-    expected = dedent(text).strip().split("\n")
+    expected = tidy(text).split("\n")
     d1 = {"name": "foo", "cnt_thresh": [1, 2], "level": ["(0,0,*,*)"]}
     d2 = {"name": "bar", "cat_thresh": [3, 4], "level": ["P1000"]}
     assert metconf._field_sequence(k="field", v=[d1, d2], level=0) == expected
@@ -283,18 +282,18 @@ def test_metconf__interp__kvpair(k, v):
     assert metconf._interp(k=k, v=v, level=1) == [f"  {k} = {v};"]
 
 
-def test_metconf__interp__type():
+def test_metconf__interp__type(tidy):
     text = """
     type = {
       method = BILIN;
       width = 2;
     }
     """
-    expected = dedent(text).strip().split("\n")
+    expected = tidy(text).split("\n")
     assert metconf._interp(k="type", v={"method": "BILIN", "width": 2}, level=0) == expected
 
 
-def test_metconf__key_val_map_list():
+def test_metconf__key_val_map_list(tidy):
     text = """
     maplist = [
       {
@@ -307,7 +306,7 @@ def test_metconf__key_val_map_list():
       }
     ];
     """
-    expected = dedent(text).strip().split("\n")
+    expected = tidy(text).split("\n")
     assert metconf._key_val_map_list(k="maplist", v={"1": "one", "2": "two"}, level=0) == expected
 
 
@@ -325,13 +324,13 @@ def test_metconf__mask_bad_key():
         metconf._mask(k="foo", v=[], level=0)
 
 
-def test_metconf__mask__grid_list():
+def test_metconf__mask__grid_list(tidy):
     text = """
     grid = [
       "FULL"
     ];
     """
-    expected = dedent(text).strip().split("\n")
+    expected = tidy(text).split("\n")
     assert metconf._mask(k="grid", v=["FULL"], level=0) == expected
 
 
@@ -367,14 +366,14 @@ def test_metconf__regrid():
         metconf._regrid(k="foo", v="bar", level=0)
 
 
-def test_metconf__sequence():
+def test_metconf__sequence(tidy):
     text = """
     s = [
       FOO,
         BAR
     ];
     """
-    expected = dedent(text).strip().split("\n")
+    expected = tidy(text).split("\n")
     v = ["foo", "  bar"]
     handler = lambda x: x.upper()
     assert metconf._sequence(k="s", v=v, handler=handler, level=0) == expected
@@ -394,14 +393,14 @@ def test_metconf__time_summary__scalar(k, v):
 
 
 @mark.parametrize(("k", "v"), [("obs_var", ["foo", "bar"]), ("type", ["min", "max"])])
-def test_metconf__time_summary__sequence(k, v):
+def test_metconf__time_summary__sequence(k, tidy, v):
     text = f'''
     {k} = [
       "{v[0]}",
       "{v[1]}"
     ];
     '''  # noqa: Q001
-    expected = dedent(text).strip().split("\n")
+    expected = tidy(text).split("\n")
     assert metconf._time_summary(k=k, v=v, level=0) == expected
 
 

--- a/src/wxvx/tests/test_metconf.py
+++ b/src/wxvx/tests/test_metconf.py
@@ -328,11 +328,11 @@ def test_metconf__mask_bad_key():
 def test_metconf__mask__grid_list(tidy):
     text = """
     grid = [
-      "FULL"
+      "G104"
     ];
     """
     expected = tidy(text).split("\n")
-    assert metconf._mask(k="grid", v=["FULL"], level=0) == expected
+    assert metconf._mask(k="grid", v=["G104"], level=0) == expected
 
 
 def test_metconf__mask__grid_str():

--- a/src/wxvx/tests/test_metconf.py
+++ b/src/wxvx/tests/test_metconf.py
@@ -3,6 +3,7 @@ from typing import Callable
 from pytest import mark, raises
 
 from wxvx import metconf
+from wxvx.types import ToGridVal
 
 # Public:
 
@@ -79,7 +80,7 @@ def test_metconf_render(tidy):
         },
         "output_prefix": "foo_bar",
         "regrid": {
-            "to_grid": "FCST",
+            "to_grid": ToGridVal.FCST.name,
         },
         "time_summary": {
             "obs_var": [],

--- a/src/wxvx/tests/test_schema.py
+++ b/src/wxvx/tests/test_schema.py
@@ -114,7 +114,7 @@ def test_schema_forecast(logged, config_data, fs):
     # Basic correctness:
     assert ok(config)
     # Certain top-level keys are required:
-    for key in ["name", "path", "projection"]:
+    for key in ["name", "path"]:
         assert not ok(with_del(config, key))
         assert logged(f"'{key}' is a required property")
     # Additional keys are not allowed:

--- a/src/wxvx/tests/test_types.py
+++ b/src/wxvx/tests/test_types.py
@@ -2,6 +2,7 @@ import re
 from copy import deepcopy
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Callable, cast
 
 import yaml
 from pytest import fixture, raises
@@ -221,13 +222,13 @@ def test_types_Paths(paths, config_data):
 def test_types_Regrid(regrid, config_data):
     obj = regrid
     assert obj.method == "NEAREST"
-    assert obj.to == "FCST"
+    assert str(obj.to) == types.ToGridVal.FCST.name
     cfg = config_data["regrid"]
     other1 = types.Regrid(**cfg)
     assert obj == other1
     other2 = types.Regrid(**{**cfg, "to": "baseline"})
     assert obj != other2
-    assert other2.to == "OBS"
+    assert str(other2.to) == types.ToGridVal.OBS.name
 
 
 def test_types_Time(config_data, time):
@@ -240,6 +241,17 @@ def test_types_Time(config_data, time):
     assert obj == other1
     other2 = types.Time(**{**cfg, "inittime": "foo"})
     assert obj != other2
+
+
+def test_types_ToGrid():
+    for f in [repr, str]:
+        f = cast(Callable, f)
+        assert f(types.ToGrid(val="baseline")) == types.ToGridVal.OBS.name
+        assert f(types.ToGrid(val="forecast")) == types.ToGridVal.FCST.name
+        assert f(types.ToGrid(val="G104")) == "G104"
+    assert hash(types.ToGrid(val="G104")) == hash(types.ToGrid(val="G104"))
+    assert types.ToGrid(val="G104") == types.ToGrid(val="G104")
+    assert types.ToGrid(val="baseline") != types.ToGrid(val="forecast")
 
 
 def test_types_VarMeta():

--- a/src/wxvx/tests/test_util.py
+++ b/src/wxvx/tests/test_util.py
@@ -52,7 +52,7 @@ def test_util_classify_data_format__file_missing(fakefs):
     path = fakefs / "no-souch-file"
     with raises(util.WXVXError) as e:
         util.classify_data_format(path=path)
-    assert str(e.value) == f"Could not determine format of {path}"
+    assert str(e.value) == f"Path not found: {path}"
 
 
 def test_util_classify_data_format__file_unrecognized(fakefs):
@@ -88,7 +88,7 @@ def test_util_classify_data_format__zarr_missing(fakefs):
     path = fakefs / "no-such-dir"
     with raises(util.WXVXError) as e:
         util.classify_data_format(path=path)
-    assert str(e.value) == f"Could not determine format of {path}"
+    assert str(e.value) == f"Path not found: {path}"
 
 
 @mark.parametrize(

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -227,7 +227,7 @@ def test_workflow__config_point_stat__atm(c, fakefs, fmt, testvars, tidy):
     path = fakefs / "point_stat.config"
     assert not path.is_file()
     workflow._config_point_stat(
-        c=c, path=path, varname="geopotential", var=testvars["gh"], prefix="atm", datafmt=fmt
+        c=c, path=path, varname="HGT", var=testvars["gh"], prefix="atm", datafmt=fmt
     )
     expected = """
     fcst = {
@@ -294,7 +294,7 @@ def test_workflow__config_point_stat__sfc(c, fakefs, fmt, testvars, tidy):
     path = fakefs / "point_stat.config"
     assert not path.is_file()
     workflow._config_point_stat(
-        c=c, path=path, varname="2m_temperature", var=testvars["2t"], prefix="sfc", datafmt=fmt
+        c=c, path=path, varname="T2M", var=testvars["2t"], prefix="sfc", datafmt=fmt
     )
     expected = """
     fcst = {
@@ -356,10 +356,9 @@ def test_workflow__config_point_stat__sfc(c, fakefs, fmt, testvars, tidy):
     assert path.read_text().strip() == expected
 
 
-def test_workflow__config_point_stat__unsupported_regrid_method(c, fakefs, logged, testvars):
+def test_workflow__config_point_stat__unsupported_regrid_method(c, fakefs, testvars):
     path = fakefs / "point_stat.config"
     assert not path.is_file()
-    c.regrid = replace(c.regrid, method="BUDGET")
     task = workflow._config_point_stat(
         c=c,
         path=path,
@@ -370,7 +369,6 @@ def test_workflow__config_point_stat__unsupported_regrid_method(c, fakefs, logge
     )
     assert not task.ready
     assert not path.is_file()
-    assert logged("Could not determine 'width' value for regrid method 'BUDGET'")
 
 
 def test_workflow__existing(fakefs):
@@ -855,7 +853,7 @@ def fcst_field(fmt: DataFormat, surface: bool) -> str:
             level = [
               "(0,0,*,*)"
             ];
-            name = "2m_temperature";
+            name = "T2M";
             set_attr_level = "Z002";
             """
         else:
@@ -863,7 +861,7 @@ def fcst_field(fmt: DataFormat, surface: bool) -> str:
             level = [
               "(0,0,*,*)"
             ];
-            name = "geopotential";
+            name = "HGT";
             set_attr_level = "P900";
             """
     elif fmt == DataFormat.GRIB:

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -462,10 +462,10 @@ def test_workflow__grid_grib__remote(c, tc, testvars):
     _grib_index_data.assert_called_with(c, outdir, tc, url=url)
 
 
-def test_workflow__grid_grib__remote_no_path(c, tc):
+def test_workflow__grid_grib__remote_no_path(c, tc, testvars):
     c.paths = replace(c.paths, grids_baseline=None)
     with raises(WXVXError) as e:
-        workflow._grid_grib(c=c, tc=tc, var=Var(name="t", level_type="isobaricInhPa", level=900))
+        workflow._grid_grib(c=c, tc=tc, var=testvars["t"])
     expected = "Config value paths.grids.baseline must be set"
     assert expected in str(e.value)
 

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -475,7 +475,7 @@ def test_workflow__grid_nc(c_real_fs, check_cf_metadata, da_with_leadtime, tc, t
     level = 900
     path = Path(c_real_fs.paths.grids_forecast, "a.nc")
     da_with_leadtime.to_netcdf(path)
-    object.__setattr__(c_real_fs.forecast, "path", str(path))
+    c_real_fs.forecast._path = str(path)
     val = workflow._grid_nc(c=c_real_fs, varname="HGT", tc=tc, var=testvars["gh"])
     assert ready(val)
     check_cf_metadata(ds=xr.open_dataset(val.ref, decode_timedelta=True), name="HGT", level=level)

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -226,7 +226,12 @@ def test_workflow__config_point_stat__atm(c, fakefs, testvars):
     path = fakefs / "point_stat.config"
     assert not path.is_file()
     workflow._config_point_stat(
-        c=c, path=path, varname="geopotential", var=testvars["gh"], prefix="atm"
+        c=c,
+        path=path,
+        varname="geopotential",
+        var=testvars["gh"],
+        prefix="atm",
+        datafmt=DataFormat.NETCDF,
     )
     expected = """
     fcst = {
@@ -294,7 +299,12 @@ def test_workflow__config_point_stat__sfc(c, fakefs, testvars):
     path = fakefs / "point_stat.config"
     assert not path.is_file()
     workflow._config_point_stat(
-        c=c, path=path, varname="2m_temperature", var=testvars["2t"], prefix="sfc"
+        c=c,
+        path=path,
+        varname="2m_temperature",
+        var=testvars["2t"],
+        prefix="sfc",
+        datafmt=DataFormat.NETCDF,
     )
     expected = """
     fcst = {
@@ -363,7 +373,12 @@ def test_workflow__config_point_stat__unsupported_regrid_method(c, fakefs, logge
     assert not path.is_file()
     c.regrid = replace(c.regrid, method="BUDGET")
     task = workflow._config_point_stat(
-        c=c, path=path, varname="geopotential", var=testvars["gh"], prefix="atm"
+        c=c,
+        path=path,
+        varname="geopotential",
+        var=testvars["gh"],
+        prefix="atm",
+        datafmt=DataFormat.NETCDF,
     )
     assert not task.ready
     assert not path.is_file()

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -168,7 +168,7 @@ def test_workflow__config_pb2nc(c, fakefs, tidy):
     workflow._config_pb2nc(c=c, path=path)
     expected = """
     mask = {
-      grid = "FULL";
+      grid = "";
     }
     message_type = [
       "ADPSFC",
@@ -218,7 +218,7 @@ def test_workflow__config_pb2nc__alt_masks(c, fakefs, tidy, to):
     mask = {
       grid = "%s";
     }
-    """ % (to or "FULL")
+    """ % (to or "")
     assert tidy(expected) in path.read_text()
 
 

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -664,6 +664,17 @@ def test_workflow__prepare_plot_data(dictkey):
         assert tdf["INTERP_PNTS"].eq(width**2).all()
 
 
+def test_workflow__regrid_width(c):
+    c.regrid = replace(c.regrid, method="BILIN")
+    assert workflow._regrid_width(c=c) == 2
+    c.regrid = replace(c.regrid, method="NEAREST")
+    assert workflow._regrid_width(c=c) == 1
+    c.regrid = replace(c.regrid, method="FOO")
+    with raises(WXVXError) as e:
+        workflow._regrid_width(c=c)
+    assert str(e.value) == "Could not determine 'width' value for regrid method 'FOO'"
+
+
 @mark.parametrize(
     ("fmt", "path"),
     [

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -168,7 +168,7 @@ def test_workflow__config_pb2nc(c, fakefs, tidy):
     workflow._config_pb2nc(c=c, path=path)
     expected = """
     mask = {
-      grid = "FCST";
+      grid = "FULL";
     }
     message_type = [
       "ADPSFC",

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -413,7 +413,11 @@ def test_workflow__grib_index_data(c, tc):
 
 
 @mark.parametrize(
-    "template", ["{root}/gfs.t00z.pgrb2.0p25.f000", "file://{root}/gfs.t00z.pgrb2.0p25.f000"]
+    "template",
+    [
+        "{root}/gfs.t00z.pgrb2.0p25.f000",
+        "file://{root}/gfs.t00z.pgrb2.0p25.f000",
+    ],
 )
 def test_workflow__grid_grib__local(template, config_data, gen_config, fakefs, tc, testvars):
     grib_path = fakefs / "gfs.t00z.pgrb2.0p25.f000"
@@ -657,9 +661,12 @@ def test_workflow__prepare_plot_data(dictkey):
         assert tdf["INTERP_PNTS"].eq(width**2).all()
 
 
-<<<<<<< HEAD
 @mark.parametrize(
-    ("fmt", "path"), [(DataFormat.NETCDF, "/path/to/a.nc"), (DataFormat.ZARR, "/path/to/a.zarr")]
+    ("fmt", "path"),
+    [
+        (DataFormat.NETCDF, "/path/to/a.nc"),
+        (DataFormat.ZARR, "/path/to/a.zarr"),
+    ],
 )
 def test_workflow__req_grid(c, fmt, path, tc, testvars):
     with patch.object(workflow, "classify_data_format", return_value=fmt):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -628,6 +628,18 @@ def test_workflow__prepare_plot_data(dictkey):
         assert tdf["INTERP_PNTS"].eq(width**2).all()
 
 
+@mark.parametrize(
+    ("fmt", "path"), [(DataFormat.NETCDF, "/path/to/a.nc"), (DataFormat.ZARR, "/path/to/a.zarr")]
+)
+def test_workflow__req_grid(c, fmt, path, tc, testvars):
+    with patch.object(workflow, "classify_data_format", return_value=fmt):
+        req = workflow._req_grid(path=path, c=c, varname="foo", tc=tc, var=testvars["2t"])
+    assert (
+        req.taskname
+        == "Forecast grid /test/grids/forecast/19700101/00/000/2t-heightAboveGround-0002.nc"
+    )
+
+
 def test_workflow__req_grid__grib(c, tc, testvars):
     path = Path("/path/to/a.grib2")
     with patch.object(workflow, "classify_data_format", return_value=DataFormat.GRIB):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -644,7 +644,7 @@ def test_workflow__meta(c):
 
 @mark.parametrize("dictkey", ["foo", "bar", "baz"])
 def test_workflow__prepare_plot_data(dictkey):
-    varname, level, dfs, stat, width = TESTDATA[dictkey]
+    _, _, dfs, stat, width = TESTDATA[dictkey]
     node = lambda x: Mock(ref=f"{x}.stat", taskname=x)
     reqs = cast(Sequence[Node], [node("node1"), node("node2")])
     with patch.object(workflow.pd, "read_csv", side_effect=dfs):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -857,6 +857,5 @@ def field_data(fmt: DataFormat) -> str:
           "Z002"
         ];
         name = "TMP";
-        set_attr_level = "Z002";
         """
     return dedent(text).strip()

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -156,7 +156,7 @@ def test_workflow__config_grid_stat(c, fakefs, testvars):
         varname="REFC",
         var=testvars["refc"],
         prefix="foo",
-        source=Source.FORECAST,
+        datafmt=DataFormat.GRIB,
         polyfile=None,
     )
     assert path.is_file()
@@ -670,19 +670,21 @@ def test_workflow__prepare_plot_data(dictkey):
 )
 def test_workflow__req_grid(c, fmt, path, tc, testvars):
     with patch.object(workflow, "classify_data_format", return_value=fmt):
-        req = workflow._req_grid(path=path, c=c, varname="foo", tc=tc, var=testvars["2t"])
+        req, datafmt = workflow._req_grid(path=path, c=c, varname="foo", tc=tc, var=testvars["2t"])
     # For netCDF and Zarr forecast datasets, the grid will be extracted from the dataset and CF-
     # decorated, so the requirement is a _grid_nc task, whose taskname is "Forecast grid ..."
     assert req.taskname.startswith("Forecast grid")
+    assert datafmt == fmt
 
 
 def test_workflow__req_grid__grib(c, tc, testvars):
     path = Path("/path/to/a.grib2")
     with patch.object(workflow, "classify_data_format", return_value=DataFormat.GRIB):
-        req = workflow._req_grid(path=path, c=c, varname="foo", tc=tc, var=testvars["2t"])
+        req, datafmt = workflow._req_grid(path=path, c=c, varname="foo", tc=tc, var=testvars["2t"])
     # For GRIB forecast datasets, the entire GRIB file will be accessed by MET, so the requirement
     # is an existing local path.
     assert req.taskname.startswith("Existing path")
+    assert datafmt == DataFormat.GRIB
 
 
 def test_workflow__req_prepbufr(fakefs):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -634,17 +634,18 @@ def test_workflow__prepare_plot_data(dictkey):
 def test_workflow__req_grid(c, fmt, path, tc, testvars):
     with patch.object(workflow, "classify_data_format", return_value=fmt):
         req = workflow._req_grid(path=path, c=c, varname="foo", tc=tc, var=testvars["2t"])
-    assert (
-        req.taskname
-        == "Forecast grid /test/grids/forecast/19700101/00/000/2t-heightAboveGround-0002.nc"
-    )
+    # For netCDF and Zarr forecast datasets, the grid will be extracted from the dataset and CF-
+    # decorated, so the requirement is a _grid_nc task, whose taskname is "Forecast grid ..."
+    assert req.taskname.startswith("Forecast grid")
 
 
 def test_workflow__req_grid__grib(c, tc, testvars):
     path = Path("/path/to/a.grib2")
     with patch.object(workflow, "classify_data_format", return_value=DataFormat.GRIB):
         req = workflow._req_grid(path=path, c=c, varname="foo", tc=tc, var=testvars["2t"])
-    assert req.taskname == f"Existing path {path}"
+    # For GRIB forecast datasets, the entire GRIB file will be accessed by MET, so the requirement
+    # is an existing local path.
+    assert req.taskname.startswith("Existing path")
 
 
 def test_workflow__req_prepbufr(fakefs):

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -566,7 +566,8 @@ def test_workflow__stats_vs_grid(c, fakefs, tc, testvars):
     mpexec.assert_called_once_with(str(runscript), rundir, taskname)
 
 
-def test_workflow__stats_vs_obs(c, fakefs, tc, testvars):
+@mark.parametrize("fmt", [DataFormat.NETCDF, DataFormat.ZARR])
+def test_workflow__stats_vs_obs(c, fakefs, fmt, tc, testvars):
     @external
     def mock(*_args, **_kwargs):
         yield "mock"
@@ -580,23 +581,24 @@ def test_workflow__stats_vs_obs(c, fakefs, tc, testvars):
     kwargs = dict(
         c=c, varname="T2M", tc=tc, var=testvars["2t"], prefix="foo", source=Source.BASELINE
     )
-    stat = taskfunc(**kwargs, dry_run=True).ref
-    cfgfile = stat.with_suffix(".config")
-    runscript = stat.with_suffix(".sh")
-    assert not stat.is_file()
-    assert not cfgfile.is_file()
-    assert not runscript.is_file()
-    with (
-        patch.object(workflow, "_grid_nc", mock),
-        patch.object(workflow, "_netcdf_from_obs", mock),
-        patch.object(workflow, "mpexec", side_effect=lambda *_: stat.touch()) as mpexec,
-    ):
-        stat.parent.mkdir(parents=True)
-        taskfunc(**kwargs)
-    assert stat.is_file()
-    assert cfgfile.is_file()
-    assert runscript.is_file()
-    mpexec.assert_called_once_with(str(runscript), rundir, taskname)
+    with patch.object(workflow, "classify_data_format", return_value=fmt):
+        stat = taskfunc(**kwargs, dry_run=True).ref
+        cfgfile = stat.with_suffix(".config")
+        runscript = stat.with_suffix(".sh")
+        assert not stat.is_file()
+        assert not cfgfile.is_file()
+        assert not runscript.is_file()
+        with (
+            patch.object(workflow, "_grid_nc", mock),
+            patch.object(workflow, "_netcdf_from_obs", mock),
+            patch.object(workflow, "mpexec", side_effect=lambda *_: stat.touch()) as mpexec,
+        ):
+            stat.parent.mkdir(parents=True)
+            taskfunc(**kwargs)
+        assert stat.is_file()
+        assert cfgfile.is_file()
+        assert runscript.is_file()
+        mpexec.assert_called_once_with(str(runscript), rundir, taskname)
 
 
 # Support Tests

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -132,9 +132,13 @@ class Cycles:
 
 
 class Forecast:
-    # Use '_projection' as a key instead of 'projection' to avoid triggering the property.
-
-    KEYS = ("coords", "mask", "name", "path", "_projection")
+    KEYS = (
+        "coords",
+        "mask",
+        "name",
+        "path",
+        "_projection",  # use '_projection' (not 'projection') to avoid triggering the property.
+    )
 
     def __init__(
         self,

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -124,7 +124,9 @@ class Cycles:
 
 
 class Forecast:
-    KEYS = ("coords", "mask", "name", "path", "projection")
+    # Use '_projection' as a key instead of 'projection' to avoid triggering the property.
+
+    KEYS = ("coords", "mask", "name", "path", "_projection")
 
     def __init__(
         self,

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -231,7 +231,8 @@ class Regrid:
     to: ToGrid | None = None
 
     def __post_init__(self):
-        _force(self, "to", ToGrid(str(self.to) or "forecast"))
+        _force(self, "to", ToGrid("forecast" if self.to is None else str(self.to)))
+        assert self.to is not None
 
 
 @dataclass(frozen=True)

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -109,10 +109,10 @@ class Cycles:
 
 @dataclass(frozen=True)
 class Forecast:
-    coords: Coords
     name: str
     path: str
-    projection: dict
+    coords: Coords | None = None
+    projection: dict | None = None
     mask: tuple[tuple[float, float]] | None = None
 
     KEYS = ("coords", "mask", "name", "path", "projection")

--- a/src/wxvx/util.py
+++ b/src/wxvx/util.py
@@ -66,6 +66,8 @@ def atomic(path: Path) -> Iterator[Path]:
 
 def classify_data_format(path: str | Path) -> DataFormat:
     path = Path(path)
+    if not path.exists():
+        raise WXVXError("Path not found: %s" % path)
     if path.is_file():
         inferred = magic.from_file(path.resolve())
         for pre, fmt in [
@@ -83,8 +85,7 @@ def classify_data_format(path: str | Path) -> DataFormat:
                 logging.exception(line)
         else:
             return DataFormat.ZARR
-    msg = f"Could not determine format of {path}"
-    raise WXVXError(msg)
+    raise WXVXError("Could not determine format of %s" % path)
 
 
 def classify_url(url: str) -> tuple[Proximity, str | Path]:

--- a/src/wxvx/variables.py
+++ b/src/wxvx/variables.py
@@ -11,7 +11,7 @@ import numpy as np
 import xarray as xr
 from pyproj import Proj
 
-from wxvx.types import VarMeta
+from wxvx.types import Coords, VarMeta
 from wxvx.util import WXVXError
 
 if TYPE_CHECKING:
@@ -244,6 +244,9 @@ class PREPBUFR(GFS):
 
 
 def da_construct(c: Config, da: xr.DataArray) -> xr.DataArray:
+    # This function is called only for netCDF/Zarr forecast datasets, for which coords config blocks
+    # will have been provided. So, for the typecheckers, assert that this is the case.
+    assert isinstance(c.forecast.coords, Coords)
     inittime = _da_val(da, c.forecast.coords.time.inittime, "initialization time", np.datetime64)
     leadtime = c.forecast.coords.time.leadtime
     validtime = c.forecast.coords.time.validtime
@@ -266,6 +269,9 @@ def da_construct(c: Config, da: xr.DataArray) -> xr.DataArray:
 
 
 def da_select(c: Config, ds: xr.Dataset, varname: str, tc: TimeCoords, var: Var) -> xr.DataArray:
+    # This function is called only for netCDF/Zarr forecast datasets, for which coords config blocks
+    # will have been provided. So, for the typecheckers, assert that this is the case.
+    assert isinstance(c.forecast.coords, Coords)
     coords = ds.coords.keys()
     dt = lambda x: np.datetime64(str(x.isoformat()))
     try:

--- a/src/wxvx/variables.py
+++ b/src/wxvx/variables.py
@@ -269,8 +269,8 @@ def da_construct(c: Config, da: xr.DataArray) -> xr.DataArray:
 
 
 def da_select(c: Config, ds: xr.Dataset, varname: str, tc: TimeCoords, var: Var) -> xr.DataArray:
-    # This function is called only for netCDF/Zarr forecast datasets, for which coords config blocks
-    # will have been provided. So, for the typecheckers, assert that this is the case.
+    # This function is called only for netCDF/Zarr forecast datasets, for which 'coords' config
+    # blocks will have been provided. So, for the typechecker, assert that this is the case.
     assert isinstance(c.forecast.coords, Coords)
     coords = ds.coords.keys()
     dt = lambda x: np.datetime64(str(x.isoformat()))

--- a/src/wxvx/variables.py
+++ b/src/wxvx/variables.py
@@ -244,8 +244,8 @@ class PREPBUFR(GFS):
 
 
 def da_construct(c: Config, da: xr.DataArray) -> xr.DataArray:
-    # This function is called only for netCDF/Zarr forecast datasets, for which coords config blocks
-    # will have been provided. So, for the typecheckers, assert that this is the case.
+    # This function is called only for netCDF/Zarr forecast datasets, for which 'coords' config
+    # blocks will have been provided. So, for the typechecker, assert that this is the case.
     assert isinstance(c.forecast.coords, Coords)
     inittime = _da_val(da, c.forecast.coords.time.inittime, "initialization time", np.datetime64)
     leadtime = c.forecast.coords.time.leadtime

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -150,11 +150,10 @@ def _config_grid_stat(
     if meta.cnt_thresh:
         for x in field_fcst, field_obs:
             x["cnt_thresh"] = meta.cnt_thresh
-    mask_grid = [] if polyfile else ["FULL"]
-    mask_poly = [polyfile.ref] if polyfile else []
+    mask = {"grid": [] if polyfile else ["FULL"], "poly": [polyfile.ref] if polyfile else []}
     config = {
         "fcst": {"field": [field_fcst]},
-        "mask": {"grid": mask_grid, "poly": mask_poly},
+        "mask": mask,
         "model": c.forecast.name,
         "nc_pairs_flag": "FALSE",
         "obs": {"field": [field_obs]},

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime
 from functools import cache
 from itertools import chain, pairwise, product
@@ -172,7 +173,7 @@ def _config_pb2nc(c: Config, path: Path):
     # selection of obs from the netCDF file created by pb2nc.
     _type = ["min", "max", "range", "mean", "stdev", "median", "p80"]
     config: dict = {
-        "mask": {"grid": c.regrid.to or "FULL"},
+        "mask": {"grid": c.regrid.to if re.match(r"^G\d{3}$", str(c.regrid.to)) else "FULL"},
         "message_type": ["ADPSFC", "ADPUPA", "AIRCAR", "AIRCFT"],
         "obs_bufr_var": ["POB", "QOB", "TOB", "UOB", "VOB", "ZOB"],
         "obs_window": {"beg": -1800, "end": 1800},
@@ -204,7 +205,11 @@ def _config_point_stat(
         "obs_window": {"beg": -900 if surface else -1800, "end": 900 if surface else 1800},
         "output_flag": {"cnt": "BOTH"},
         "output_prefix": f"{prefix}",
-        "regrid": {"method": c.regrid.method, "to_grid": c.regrid.to, "width": _regrid_width(c)},
+        "regrid": {
+            "method": c.regrid.method,
+            "to_grid": c.regrid.to,
+            "width": _regrid_width(c),
+        },
         "tmp_dir": path.parent,
     }
     with atomic(path) as tmp:

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -260,7 +260,9 @@ def _config_point_stat(
         if datafmt == DataFormat.GRIB
         else ("(0,0,*,*)", varname)
     )
-    field_fcst = {"level": [level_fcst], "name": name_fcst, "set_attr_level": level_obs}
+    field_fcst = {"level": [level_fcst], "name": name_fcst}
+    if datafmt != DataFormat.GRIB:
+        field_fcst["set_attr_level"] = level_obs
     field_obs = {"level": [level_obs], "name": baseline_class.varname(var.name)}
     surface = var.level_type in ("heightAboveGround", "surface")
     try:

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -254,10 +254,11 @@ def _config_point_stat(
     yield None
     level_obs = metlevel(var.level_type, var.level)
     baseline_class = variables.model_class(c.baseline.name)
-    level_fcst, name_fcst, model = (
-        (level_obs, baseline_class.varname(var.name), c.baseline.name)
+    model = c.forecast.name
+    level_fcst, name_fcst = (
+        (level_obs, baseline_class.varname(var.name))
         if datafmt == DataFormat.GRIB
-        else ("(0,0,*,*)", varname, c.forecast.name)
+        else ("(0,0,*,*)", varname)
     )
     field_fcst = {"level": [level_fcst], "name": name_fcst, "set_attr_level": level_obs}
     field_obs = {"level": [level_obs], "name": baseline_class.varname(var.name)}

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -173,7 +173,7 @@ def _config_pb2nc(c: Config, path: Path):
     # selection of obs from the netCDF file created by pb2nc.
     _type = ["min", "max", "range", "mean", "stdev", "median", "p80"]
     config: dict = {
-        "mask": {"grid": c.regrid.to if re.match(r"^G\d{3}$", str(c.regrid.to)) else "FULL"},
+        "mask": {"grid": c.regrid.to if re.match(r"^G\d{3}$", str(c.regrid.to)) else ""},
         "message_type": ["ADPSFC", "ADPUPA", "AIRCAR", "AIRCFT"],
         "obs_bufr_var": ["POB", "QOB", "TOB", "UOB", "VOB", "ZOB"],
         "obs_window": {"beg": -1800, "end": 1800},

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -150,10 +150,9 @@ def _config_grid_stat(
     if meta.cnt_thresh:
         for x in field_fcst, field_obs:
             x["cnt_thresh"] = meta.cnt_thresh
-    mask = {"grid": [] if polyfile else ["FULL"], "poly": [polyfile.ref] if polyfile else []}
     config = {
         "fcst": {"field": [field_fcst]},
-        "mask": mask,
+        "mask": {"grid": [] if polyfile else ["FULL"], "poly": [polyfile.ref] if polyfile else []},
         "model": c.forecast.name,
         "nc_pairs_flag": "FALSE",
         "obs": {"field": [field_obs]},

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -144,12 +144,12 @@ def _config_grid_stat(
     yield None
     field_fcst, field_obs = _config_fields(c, varname, var, datafmt)
     meta = _meta(c, varname)
-    if meta.cat_thresh:
-        for x in field_fcst, field_obs:
-            x["cat_thresh"] = meta.cat_thresh
-    if meta.cnt_thresh:
-        for x in field_fcst, field_obs:
-            x["cnt_thresh"] = meta.cnt_thresh
+    # if meta.cat_thresh:
+    #     for x in field_fcst, field_obs:
+    #         x["cat_thresh"] = meta.cat_thresh
+    # if meta.cnt_thresh:
+    #     for x in field_fcst, field_obs:
+    #         x["cnt_thresh"] = meta.cnt_thresh
     config = {
         "fcst": {"field": [field_fcst]},
         "mask": {"grid": [] if polyfile else ["FULL"], "poly": [polyfile.ref] if polyfile else []},
@@ -457,6 +457,13 @@ def _config_fields(c: Config, varname: str, var: Var, datafmt: DataFormat):
     if datafmt != DataFormat.GRIB:
         field_fcst["set_attr_level"] = level_obs
     field_obs = {"level": [level_obs], "name": varname_baseline}
+    meta = _meta(c, varname)
+    if meta.cat_thresh:
+        for x in field_fcst, field_obs:
+            x["cat_thresh"] = meta.cat_thresh
+    if meta.cnt_thresh:
+        for x in field_fcst, field_obs:
+            x["cnt_thresh"] = meta.cnt_thresh
     return field_fcst, field_obs
 
 

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -144,12 +144,6 @@ def _config_grid_stat(
     yield None
     field_fcst, field_obs = _config_fields(c, varname, var, datafmt)
     meta = _meta(c, varname)
-    # if meta.cat_thresh:
-    #     for x in field_fcst, field_obs:
-    #         x["cat_thresh"] = meta.cat_thresh
-    # if meta.cnt_thresh:
-    #     for x in field_fcst, field_obs:
-    #         x["cnt_thresh"] = meta.cnt_thresh
     config = {
         "fcst": {"field": [field_fcst]},
         "mask": {"grid": [] if polyfile else ["FULL"], "poly": [polyfile.ref] if polyfile else []},


### PR DESCRIPTION
Fixes #22.

I manually tested a number of cases to check for regressions, including a netCDF forecast dataset vs grid, then again vs obs, with both `latlon` and `lcc` projections. I also of course tested a cycle of HRRRCast GRIB-formatted forecast data.