### PR TITLE
Fix model labeling bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ An overview of the content of the YAML configuration file specified via `-c` / `
 
 ### baseline.name
 
-Name of the baseline to verify against. Currently supported values are: `GFS`, `HRRR`, `PREPBUFR`. This value guides `wxvx` in identification of baseline data (grids or obs) corresponding to the forecast variable being verified. This name will also appear in MET stat output.
+Name of the baseline to verify against. Currently supported values are: `GFS`, `HRRR`, `PREPBUFR`. This value guides `wxvx` in identification of baseline data (grids or obs) corresponding to the forecast variable being verified. This name will also appear in MET stat output. This name must differ from `forecast.name`.
 
 ### baseline.type
 
@@ -130,7 +130,7 @@ The `forecast.mask` value may be omitted, or set to the YAML value `null`, in wh
 
 ### forecast.name
 
-An arbitrary value identifying the forecast model being verified. This name will appear in MET stat output.
+An arbitrary value identifying the forecast model being verified. This name will appear in MET stat output. This name must differ from `baseline.name`.
 
 ### forecast.path
 

--- a/src/wxvx/tests/test_types.py
+++ b/src/wxvx/tests/test_types.py
@@ -132,6 +132,12 @@ def test_types_Config__bad_regrid_to(config_data):
     assert str(e.value) == "Cannot regrid to observations per regrid.to config value"
 
 
+def test_types_Config__bad_same_names(config_data):
+    with raises(WXVXError) as e:
+        types.Config(raw=with_set(config_data, config_data["baseline"]["name"], "forecast", "name"))
+    assert str(e.value) == "baseline.name and forecast.name must differ"
+
+
 def test_types_Coords(config_data, coords):
     obj = coords
     assert hash(obj)

--- a/src/wxvx/tests/test_workflow.py
+++ b/src/wxvx/tests/test_workflow.py
@@ -134,12 +134,14 @@ def test_workflow_stats(c, noop):
     assert len(val.ref) == len(c.variables) + 1  # for 2x SPFH levels
 
 
-def test_workflow__config_grid_stat(c, fakefs, testvars):
+@mark.parametrize("source", [Source.BASELINE, Source.FORECAST])
+def test_workflow__config_grid_stat(c, source, fakefs, testvars):
     path = fakefs / "refc.config"
     assert not path.is_file()
     workflow._config_grid_stat(
         c=c,
         path=path,
+        source=source,
         varname="REFC",
         var=testvars["refc"],
         prefix="foo",
@@ -214,7 +216,13 @@ def test_workflow__config_point_stat__atm(c, fakefs, fmt, testvars, tidy):
     path = fakefs / "point_stat.config"
     assert not path.is_file()
     workflow._config_point_stat(
-        c=c, path=path, varname="HGT", var=testvars["gh"], prefix="atm", datafmt=fmt
+        c=c,
+        path=path,
+        source=Source.FORECAST,
+        varname="HGT",
+        var=testvars["gh"],
+        prefix="atm",
+        datafmt=fmt,
     )
     expected = """
     fcst = {
@@ -281,7 +289,13 @@ def test_workflow__config_point_stat__sfc(c, fakefs, fmt, testvars, tidy):
     path = fakefs / "point_stat.config"
     assert not path.is_file()
     workflow._config_point_stat(
-        c=c, path=path, varname="T2M", var=testvars["2t"], prefix="sfc", datafmt=fmt
+        c=c,
+        path=path,
+        source=Source.FORECAST,
+        varname="T2M",
+        var=testvars["2t"],
+        prefix="sfc",
+        datafmt=fmt,
     )
     expected = """
     fcst = {
@@ -349,6 +363,7 @@ def test_workflow__config_point_stat__unsupported_regrid_method(c, fakefs, testv
     task = workflow._config_point_stat(
         c=c,
         path=path,
+        source=Source.FORECAST,
         varname="geopotential",
         var=testvars["gh"],
         prefix="atm",

--- a/src/wxvx/types.py
+++ b/src/wxvx/types.py
@@ -97,8 +97,12 @@ class Config:
         return "%s(%s)" % (self.__class__.__name__, ", ".join(parts))
 
     def _validate(self) -> None:
-        # Validation tests involving disparate config subtrees, which are awkward to define in JSON
-        # Schema (or that give poor user feedback when so defined) are performed here.
+        # Validation tests that span disparate config subtrees are awkward to express in
+        # JSON Schema (or yield poor user-facing feedback) and are instead enforced here
+        # with explicit checks.
+        if self.baseline.name == self.forecast.name:
+            msg = "baseline.name and forecast.name must differ"
+            raise WXVXError(msg)
         if self.baseline.type == VxType.GRID and not self.paths.grids_baseline:
             msg = "Specify path.grids.baseline when baseline.type is 'grid'"
             raise WXVXError(msg)

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -158,7 +158,7 @@ def _config_grid_stat(
     config = {
         "fcst": {"field": [field_fcst]},
         "mask": {"grid": [] if polyfile else ["FULL"], "poly": [polyfile.ref] if polyfile else []},
-        "model": c.baseline.name if source == Source.BASELINE else c.forecast.name,
+        "model": _model(c, source),
         "nc_pairs_flag": "FALSE",
         "obs": {"field": [field_obs]},
         "obtype": c.baseline.name,
@@ -210,7 +210,7 @@ def _config_point_stat(
         "interp": {"shape": "SQUARE", "type": {"method": "BILIN", "width": 2}, "vld_thresh": 1.0},
         "message_type": ["SFC" if surface else "ATM"],
         "message_type_group_map": {"ATM": "ADPUPA,AIRCAR,AIRCFT", "SFC": "ADPSFC"},
-        "model": c.baseline.name if source == Source.BASELINE else c.forecast.name,
+        "model": _model(c, source),
         "obs": {"field": [field_obs]},
         "obs_window": {"beg": -900 if surface else -1800, "end": 900 if surface else 1800},
         "output_flag": {"cnt": "BOTH"},
@@ -486,6 +486,13 @@ def _enforce_point_baseline_type(c: Config, taskname: str):
 
 def _meta(c: Config, varname: str) -> VarMeta:
     return VARMETA[c.variables[varname]["name"]]
+
+
+def _model(c: Config, source: Source) -> str:
+    model = c.forecast.name if source == Source.FORECAST else c.baseline.name
+    if c.forecast.name == c.baseline.name:
+        model = f"{model} ({source.name.lower()})"
+    return model
 
 
 def _prepare_plot_data(reqs: Sequence[Node], stat: str, width: int | None) -> pd.DataFrame:

--- a/src/wxvx/workflow.py
+++ b/src/wxvx/workflow.py
@@ -158,7 +158,7 @@ def _config_grid_stat(
     config = {
         "fcst": {"field": [field_fcst]},
         "mask": {"grid": [] if polyfile else ["FULL"], "poly": [polyfile.ref] if polyfile else []},
-        "model": _model(c, source),
+        "model": c.baseline.name if source == Source.BASELINE else c.forecast.name,
         "nc_pairs_flag": "FALSE",
         "obs": {"field": [field_obs]},
         "obtype": c.baseline.name,
@@ -210,7 +210,7 @@ def _config_point_stat(
         "interp": {"shape": "SQUARE", "type": {"method": "BILIN", "width": 2}, "vld_thresh": 1.0},
         "message_type": ["SFC" if surface else "ATM"],
         "message_type_group_map": {"ATM": "ADPUPA,AIRCAR,AIRCFT", "SFC": "ADPSFC"},
-        "model": _model(c, source),
+        "model": c.baseline.name if source == Source.BASELINE else c.forecast.name,
         "obs": {"field": [field_obs]},
         "obs_window": {"beg": -900 if surface else -1800, "end": 900 if surface else 1800},
         "output_flag": {"cnt": "BOTH"},
@@ -486,13 +486,6 @@ def _enforce_point_baseline_type(c: Config, taskname: str):
 
 def _meta(c: Config, varname: str) -> VarMeta:
     return VARMETA[c.variables[varname]["name"]]
-
-
-def _model(c: Config, source: Source) -> str:
-    model = c.forecast.name if source == Source.FORECAST else c.baseline.name
-    if c.forecast.name == c.baseline.name:
-        model = f"{model} ({source.name.lower()})"
-    return model
 
 
 def _prepare_plot_data(reqs: Sequence[Node], stat: str, width: int | None) -> pd.DataFrame:


### PR DESCRIPTION
Both the forecast and baseline `.txt` files were getting the forecast's model name, so when the plotting function got ahold of the two `.txt` files, both were labeled with the forecast's name, and it then interpreted it as being two data points for the same forecast. 